### PR TITLE
21: Run AR-B1 cost-model probe + fix BQ adapter TableRef bug

### DIFF
--- a/.claude/rules/warehouse-adapters.md
+++ b/.claude/rules/warehouse-adapters.md
@@ -134,6 +134,19 @@ The adapter emits sparing `WARNING`-level signal when behaviour deviates from th
 
 `INFO` and `DEBUG` are reserved for the prune/grade stages where signal-vs-volume tradeoffs surface. Don't add adapter-level INFO logging in v0.1.
 
+## Don't pass our `TableRef` straight into vendor SDK methods (issue #21 lesson)
+
+Third-party SDK methods that "take a table reference" accept a fixed set of vendor types — `bigquery.Client.get_table()` accepts `str | bigquery.TableReference | Table | TableListItem` and explodes on `AttributeError: 'TableRef' object has no attribute 'path'` when handed our Pydantic value object. Our `TableRef` has the same field names but is not duck-compatible with the SDK's internal type checks.
+
+Always pass the **stringified form** (`ref.qualified_name`) to vendor SDK call sites. Two-part `dataset.table` (when `project=None`) is a valid `qualified_name` shape; the BQ SDK resolves the project from the client's billing project. The rule applies symmetrically in tests: `FakeBigQueryClient._coerce_to_tableref` accepts both `str` (parsed) and `TableReference`-shape (duck-typed via `.dataset_id` / `.table_id`).
+
+This bug shipped silently in the BigQuery adapter (#3) for two issues' worth of work because every test that exercised `_get_table` used `FakeBigQueryClient`, which matched on `TableRef` equality and never noticed the production path was wrong. The integration tests at `tests/warehouse/test_bigquery_integration.py` had the same defect and were never run live. Issue #21's AR-B1 cost probe was the first code path that touched a real BQ client and broke.
+
+Two takeaways for future adapter work:
+
+1. Every public adapter method that calls `client.<method>(ref, ...)` needs a live integration test that runs against the real SDK, not just the fake. The fake is for behaviour assertions; only the real SDK enforces input-type contracts. Gate the live test on `SF_RUN_BQ=1` (or per-vendor equivalent) so default CI stays free, but require maintainers to run it before declaring an adapter "done."
+2. When the fake's coercion helper has a special case for accepting strings, that's a load-bearing signal that the production path passes strings — don't accept non-string forms in the fake without a paired test that proves the real SDK accepts them too.
+
 ## Reference
 
 `plans/super/3-bigquery-adapter.md` — DEC-001 … DEC-028. `src/signalforge/warehouse/` — current implementation. `tests/warehouse/_fake.py` — `FakeBigQueryClient` + `expect_*` API. `docs/warehouse-adapter-ops.md` — operational reference.

--- a/docs/prune-ops.md
+++ b/docs/prune-ops.md
@@ -179,17 +179,25 @@ SF_RUN_BQ=1 pytest -m bigquery tests/warehouse/test_sample_cost_probe.py -s
 
 The probe currently fails (rather than `xfail`s) on the
 `bytesBilledLimitExceeded` path because the assertion ceiling and the
-adapter cap are decoupled — refining the probe to extract the estimate
-from the `InternalServerError` message and `xfail` cleanly is tracked as
-a follow-up. The 9.92 GB figure is captured directly from the error:
-`Query exceeded limit for bytes billed: 100000000. 9924771840 or higher
-required.`
+adapter cap are decoupled. Refining the probe to detect the BigQuery
+reason code `bytesBilledLimitExceeded` (which appears in the error
+message regardless of HTTP status) and `xfail` cleanly is tracked as a
+follow-up. Note the SDK exception class is unstable on this path: the
+adapter's `map_bq_exception` (`adapters/_client.py`) catches
+`google.api_core.exceptions.BadRequest` (HTTP 400), but the live run
+on 2026-05-01 with `google-cloud-bigquery==3.41.0` raised
+`google.api_core.exceptions.InternalServerError` (HTTP 500). The reason
+code is the durable identifier; match on substring rather than the
+exception class. The 9.92 GB figure is captured directly from the
+error message: `Query exceeded limit for bytes billed: 100000000.
+9924771840 or higher required.`
 
 **Q4=A is NOT adequate for v0.1 sample-mode on wide tables.** Issue #22
 tracks Q4=C escalation (temp-table-materialised sample) for v0.2. In the
 meantime, sample-mode prune runs on tables wider than ~10 columns will
 either trip the adapter's 100 MB cap and fail, or — if a maintainer
-raises the cap via `cost_limit_bytes` per-call — bill at roughly
+raises the cap via the profile-level `maximum_bytes_billed` field
+(`load_profile`, see `docs/warehouse-adapter-ops.md`) — bill at roughly
 `(rows × bytes_per_row)` for **every test** in the candidate set.
 Schema-only mode remains the v0.1 default precisely because the cost
 model for sample-mode is not where we want it.

--- a/docs/prune-ops.md
+++ b/docs/prune-ops.md
@@ -157,28 +157,47 @@ cost approximately 24 MB / approximately one tenth of one US cent
 assumed only the column under test would be read; the worst case is
 50–500x that figure.
 
-**Verified figure (US-003): pending in-environment run.** The diagnostic
-probe at `tests/warehouse/test_sample_cost_probe.py` runs against
-`bigquery-public-data.iowa_liquor_sales.sales` and records
-`total_bytes_billed` for a 100k-row deterministic sample. To run it:
+**Verified figure (US-003): 9,924,771,840 bytes (≈9.92 GB), run 2026-05-01
+against `bigquery-public-data.iowa_liquor_sales.sales` (~30M rows, ~24
+columns), 100k-row deterministic sample.** AR-B1 confirmed: the
+`TO_JSON_STRING(t)` predicate triggers a full-row scan, and the actual
+cost is **~99× the Phase-1 estimate** (24 MB) and ~2× the probe's 5 GB
+sanity ceiling. The figure is BigQuery's pre-execution analyzer estimate;
+the adapter's 100 MB `maximum_bytes_billed` cap (DEC-005) blocked the
+query before execution, so this is the cost the user would pay if the
+cap were lifted, not a measured `total_bytes_billed` off a completed
+job. The pre-execution estimate matches what BQ would bill on a real
+prune run (the analyzer reads the same statistics the billing pipeline
+uses).
+
+To reproduce:
 
 ```bash
 gcloud auth application-default login
 SF_RUN_BQ=1 pytest -m bigquery tests/warehouse/test_sample_cost_probe.py -s
 ```
 
-Probe thresholds (constants in the test):
+The probe currently fails (rather than `xfail`s) on the
+`bytesBilledLimitExceeded` path because the assertion ceiling and the
+adapter cap are decoupled — refining the probe to extract the estimate
+from the `InternalServerError` message and `xfail` cleanly is tracked as
+a follow-up. The 9.92 GB figure is captured directly from the error:
+`Query exceeded limit for bytes billed: 100000000. 9924771840 or higher
+required.`
+
+**Q4=A is NOT adequate for v0.1 sample-mode on wide tables.** Issue #22
+tracks Q4=C escalation (temp-table-materialised sample) for v0.2. In the
+meantime, sample-mode prune runs on tables wider than ~10 columns will
+either trip the adapter's 100 MB cap and fail, or — if a maintainer
+raises the cap via `cost_limit_bytes` per-call — bill at roughly
+`(rows × bytes_per_row)` for **every test** in the candidate set.
+Schema-only mode remains the v0.1 default precisely because the cost
+model for sample-mode is not where we want it.
+
+Probe thresholds (constants in the test, kept for the post-Q4=C run):
 
 - `_BYTES_WARN_AT = 500_000_000` (500 MB) — soft WARNING fires above this.
 - `_BYTES_CEILING = 5_000_000_000` (5 GB) — assertion fires above this; the test fails.
-
-Outcome interpretation:
-
-- **`bytes_billed < 500 MB`** → Q4=A (one-query-per-test) is viable for v0.1 unchanged. The Phase-1 plan's cost target holds.
-- **`bytes_billed >= 500 MB`** → adopt Q4=C (temp-table-materialised sample) in v0.2 so the per-test cost amortises across the candidate set rather than re-paying the full-row scan for every test.
-
-Update this section once a maintainer with BigQuery credentials runs the
-probe.
 
 ## Audit JSONL schema
 

--- a/src/signalforge/warehouse/adapters/bigquery.py
+++ b/src/signalforge/warehouse/adapters/bigquery.py
@@ -303,7 +303,7 @@ class BigQueryAdapter(WarehouseAdapter):
         if cache is not None and table in cache:
             return cache[table]
         try:
-            meta = self._get_client().get_table(table)
+            meta = self._get_client().get_table(table.qualified_name)
         except Exception as exc:
             mapped = map_bq_exception(
                 exc,

--- a/tests/warehouse/_fake.py
+++ b/tests/warehouse/_fake.py
@@ -164,4 +164,7 @@ class FakeBigQueryClient:
 
 
 def _coerce_to_tableref(ref: Any) -> TableRef:
+    if isinstance(ref, str):
+        project, dataset, name = ref.split(".")
+        return TableRef(project=project, dataset=dataset, name=name)
     return TableRef(project=ref.project, dataset=ref.dataset_id, name=ref.table_id)

--- a/tests/warehouse/_fake.py
+++ b/tests/warehouse/_fake.py
@@ -165,6 +165,15 @@ class FakeBigQueryClient:
 
 def _coerce_to_tableref(ref: Any) -> TableRef:
     if isinstance(ref, str):
-        project, dataset, name = ref.split(".")
-        return TableRef(project=project, dataset=dataset, name=name)
+        parts = ref.split(".")
+        if len(parts) == 3:
+            project, dataset, name = parts
+            return TableRef(project=project, dataset=dataset, name=name)
+        if len(parts) == 2:
+            dataset, name = parts
+            return TableRef(project=None, dataset=dataset, name=name)
+        raise AssertionError(
+            "table reference strings must be 'dataset.table' or "
+            f"'project.dataset.table', got: {ref!r}"
+        )
     return TableRef(project=ref.project, dataset=ref.dataset_id, name=ref.table_id)

--- a/tests/warehouse/test_sample_cost_probe.py
+++ b/tests/warehouse/test_sample_cost_probe.py
@@ -131,7 +131,7 @@ def _issue_sample_capture_bytes_billed(
     process emitting the same ``signalforge_stage`` label).
     """
     client = adapter._get_client()  # noqa: SLF001  # documented seam
-    table = client.get_table(target)
+    table = client.get_table(target.qualified_name)
     num_rows = getattr(table, "num_rows", None)
     if not num_rows:
         # Public dataset; this is a defensive guard rather than a


### PR DESCRIPTION
Closes #21.

## Summary

- AR-B1 cost-model probe ran 2026-05-01 against `bigquery-public-data.iowa_liquor_sales.sales` (~30M rows, ~24 cols) for a 100k-row deterministic sample. **Verified figure: 9,924,771,840 bytes (≈9.92 GB)** — ~99× the Phase-1 estimate and ~2× the probe's 5 GB sanity ceiling. BigQuery's pre-execution analyzer rejected the query because the adapter's 100 MB `maximum_bytes_billed` cap (DEC-005 of #3) is below the analyzer's estimate; the figure is captured from the `bytesBilledLimitExceeded` error rather than `total_bytes_billed` off a completed job.
- `docs/prune-ops.md` Cost model section now records the verified figure + run date, and explicitly states Q4=A is **not** adequate for v0.1 sample-mode on wide tables. Schema-only stays the v0.1 default.
- Q4=C (temp-table-materialised sample) follow-up filed as #22.

## Side-quest: BQ adapter `TableRef`/`get_table` bug

The probe's first failure was an `AttributeError: 'TableRef' object has no attribute 'path'` from inside the BQ SDK. Root cause: `BigQueryAdapter._get_table()` and the probe both passed our Pydantic `TableRef` straight into `google.cloud.bigquery.Client.get_table(...)`, which only accepts `str | TableReference | Table | TableListItem`. Both call sites now pass `qualified_name` (a string), and `FakeBigQueryClient._coerce_to_tableref` learned to parse the dotted form so unit tests still bind the production path.

Same call shape exists in `tests/warehouse/test_bigquery_integration.py` (`sample_rows`, `column_stats`) — those would have failed identically against live BQ; they were never run live. The fix makes them reachable as a side-effect; live verification remains a separate concern (BQ-gated, opt-in via `SF_RUN_BQ=1`).

## Test plan

- [x] `pytest -q` — 725 passed, 9 deselected.
- [x] `SF_RUN_BQ=1 pytest -m bigquery tests/warehouse/test_sample_cost_probe.py -v -s` — surfaces the 9.92 GB figure via `bytesBilledLimitExceeded`. Probe currently fails (rather than xfails) on that branch; refining the probe to extract the estimate and `xfail` cleanly is noted inline in `docs/prune-ops.md` as a follow-up.
- [ ] Re-run the AR-B1 probe after #22 lands (Q4=C); expect per-test bytes_billed to drop into the 1–10 MB range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cost-model verification documentation with verified pre-execution estimates (~9.92 GB) for large-scale data sampling scenarios.
  * Documented adapter capacity constraints and their impact on execution flow for wide-table operations.
  * Refined guidance on sample-mode adequacy across product versions with escalation tracking for future improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->