### PR TITLE
38: align fail-closed audit writers (no try/except + short-write loop)

### DIFF
--- a/.claude/rules/safety-layer.md
+++ b/.claude/rules/safety-layer.md
@@ -74,6 +74,14 @@ _LOGGER.info("audit event: %s", json.dumps({"unique_id": event.model_unique_id, 
 
 If you add a new module that genuinely needs to construct an `LLMRequest` (e.g., a deserialiser for resumption), update the AST-scan exclusion list AND document the audit-write seam. Don't suppress the test.
 
+## Fail-closed writer shape — Scan 8 covers all five writers (issue #38)
+
+`tests/test_audit_completeness.py::test_fail_closed_writers_have_no_except_around_write_fsync` and `test_fail_closed_writers_use_short_write_loop` are the eighth AST scan in the project. They walk every fail-closed writer module — `signalforge.{safety,draft,prune,grade}.audit` and `signalforge.diff._sidecar` — and assert: (a) no `except` handler may wrap a `Try` whose body issues `os.write` / `os.fsync` (only a `try / finally` around `os.close(fd)` is permitted); (b) every writer function uses a `while` loop around `os.write` so short writes (`EINTR`, pathological short returns) don't produce partial JSONL records.
+
+The typed-error wrap (`AuditWriteError`, `LLMResponseAuditWriteError`, `PruneAuditWriteError`, `GradeAuditWriteError`, `DiffSidecarWriteError`) lives at the orchestrator boundary (`build_llm_request`, `draft_from_request`, `prune_tests`, `grade_artifacts`, `render_diff`), not inside the writer. `AuditRecordTooLargeError` (and its layer-specific cousins) raises from inside the writer — pre-open, so no on-disk artefact — and propagates as-is.
+
+When a v0.3 stage ships a sixth fail-closed writer (a CLI run-history audit, a multi-model batch checkpointer, etc.), extend `_FAIL_CLOSED_WRITER_MODULES` in the scan to a sixth entry. The writer module must mirror the prune/grade/diff template verbatim: serialise → size-check → `mkdir -p` → `os.open(O_APPEND | O_CREAT | O_WRONLY, 0o600)` → short-write `while` loop → `os.fsync` → close. The orchestrator owns the typed wrap.
+
 ## Pydantic v2 `with_mode` re-runs validators (DEC-018)
 
 `SafetyPolicy.with_mode(mode)` does NOT use `model_copy(update=...)` — that path silently skips `@model_validator(mode="after")`, which means going through the documented CLI override seam would silently enable sample mode without emitting the DEC-021 WARNING.

--- a/src/signalforge/draft/audit.py
+++ b/src/signalforge/draft/audit.py
@@ -224,7 +224,20 @@ def write_response_event(event: LLMResponseEvent, *, audit_path: Path) -> None:
     # ``OSError`` propagates so the caller drops the partial response.
     fd = os.open(str(audit_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
     try:
-        os.write(fd, payload)
+        # ``os.write`` may return fewer bytes than requested (EINTR on a
+        # signal-interrupted call, or short writes on certain filesystems
+        # / kernels). Loop until the full payload lands; raise on a
+        # zero-byte return (disk full / unrecoverable I/O failure).
+        # POSIX atomicity for ``O_APPEND`` writes still holds at the
+        # ``write(2)`` boundary up to ``PIPE_BUF``; the loop is the
+        # documented short-write recovery, not a contract violation.
+        # Mirrors prune/grade/diff/safety.
+        written = 0
+        while written < len(payload):
+            n = os.write(fd, payload[written:])
+            if n == 0:
+                raise OSError("os.write returned 0 — disk full or other I/O failure")
+            written += n
         os.fsync(fd)
     finally:
         # Best-effort close; the write/fsync above already succeeded

--- a/src/signalforge/safety/audit.py
+++ b/src/signalforge/safety/audit.py
@@ -12,11 +12,15 @@ Three load-bearing properties:
   guarantees ``write(2)`` is atomic up to ``PIPE_BUF`` (4 KiB on Linux); the
   module-level :data:`_AUDIT_RECORD_LIMIT_BYTES` enforces a 4000-byte cap with
   a 96-byte margin so concurrent writers cannot interleave partial records.
-* **Fail-closed on every error** (DEC-011). Serialisation errors, ``mkdir``
-  failures, ``open`` failures, ``write`` / ``fsync`` failures all propagate
-  as :class:`AuditWriteError`. Oversize records propagate as
-  :class:`AuditRecordTooLargeError`. Callers (the request builder in US-008)
-  must abort on either, never swallow.
+* **Fail-closed on every error** (DEC-011). ``write`` catches NO exceptions
+  internally — serialisation errors, ``mkdir`` failures, ``open`` failures,
+  ``write`` / ``fsync`` failures all propagate raw to the caller. The
+  orchestrator (:func:`signalforge.safety.request.build_llm_request`) wraps
+  non-typed propagations as :class:`AuditWriteError`. Oversize records raise
+  :class:`AuditRecordTooLargeError` BEFORE any file is opened, so the
+  serialised line never lands on disk. The propagation IS the defence —
+  don't add try/except around the writes "to be defensive". This mirrors
+  the writer shape in prune / grade / diff / draft.
 * **ANSI-safe lazy-format logger** (DEC-022). The summary line is logged via
   ``%s`` lazy-format with ``json.dumps`` of the user-controlled fields. f-string
   interpolation here would let a crafted ``model_unique_id`` containing raw
@@ -53,6 +57,16 @@ _AUDIT_RECORD_LIMIT_BYTES: Final[int] = 4000
 def write(event: AuditEvent, audit_path: Path) -> None:
     """Append a single JSONL record to ``audit_path``. Fail-closed.
 
+    Mirrors :func:`signalforge.prune.audit._write_prune_event`,
+    :func:`signalforge.draft.audit.write_response_event`,
+    :func:`signalforge.grade.audit.write_grade_event`, and
+    :func:`signalforge.diff._sidecar.write_sidecar` semantics exactly:
+    serialise → size-check (BEFORE any file open) → ``mkdir -p`` parent →
+    ``os.open(O_APPEND | O_CREAT | O_WRONLY, 0o600)`` → looped ``os.write``
+    → ``os.fsync`` → close. Catches NO exceptions internally; the
+    ``try / finally`` around ``os.close`` only guarantees the descriptor is
+    released, it does NOT swallow ``write`` / ``fsync`` failures.
+
     Args:
         event: the :class:`~signalforge.safety.models.AuditEvent` to persist.
         audit_path: absolute or project-relative path; the parent directory
@@ -60,54 +74,66 @@ def write(event: AuditEvent, audit_path: Path) -> None:
             itself is created with mode ``0o600`` on first call.
 
     Raises:
-        AuditWriteError: any underlying ``OSError`` / ``PermissionError`` /
-            ``IOError``, or a JSON-encoding failure. DEC-011 fail-closed:
-            callers (the request builder) abort the LLM call rather than
-            proceed without an audit record.
         AuditRecordTooLargeError: the serialised line exceeds the
             POSIX-atomic-append size cap (DEC-022); reduce ``columns_sent``
-            or ``redactions`` count.
+            or ``redactions`` count. Raised BEFORE any file is opened —
+            an oversize record leaves no on-disk artefact.
+        OSError: any underlying I/O failure (``PermissionError``,
+            ``FileNotFoundError``, etc.) and any JSON-encoding failure
+            (raw :class:`TypeError` / :class:`ValueError` from
+            :func:`json.dumps`) propagates raw. The caller
+            (:func:`signalforge.safety.request.build_llm_request`) wraps
+            non-typed propagations as
+            :class:`signalforge.safety.errors.AuditWriteError`.
     """
     # Local import keeps ``audit`` importable without forcing the errors module
     # at module-eval time and matches the style used elsewhere in the package.
-    from signalforge.safety.errors import AuditRecordTooLargeError, AuditWriteError
+    from signalforge.safety.errors import AuditRecordTooLargeError
 
-    # Serialise the event. Any encoding error (e.g. unserialisable custom
-    # type smuggled through ``model_construct``) becomes ``AuditWriteError``.
-    try:
-        payload = event.model_dump(mode="json")
-        line = json.dumps(payload, separators=(",", ":")) + "\n"
-    except Exception as exc:
-        raise AuditWriteError(path=audit_path, cause=exc) from exc
-
+    # Serialise. Any encoding error (e.g. an unserialisable smuggled type)
+    # propagates raw; the orchestrator wraps as ``AuditWriteError``.
+    payload = event.model_dump(mode="json")
+    line = json.dumps(payload, separators=(",", ":")) + "\n"
     encoded = line.encode("utf-8")
+
+    # Size check BEFORE any file open so an oversize record leaves no
+    # on-disk artefact. Mirrors prune/draft/grade/diff.
     if len(encoded) > _AUDIT_RECORD_LIMIT_BYTES:
         raise AuditRecordTooLargeError(size=len(encoded), limit=_AUDIT_RECORD_LIMIT_BYTES)
 
     # Ensure parent dir exists with private permissions. ``mode=0o700`` is the
     # umask-respecting permission used at *creation* time; an existing dir is
-    # left alone (``exist_ok=True``).
-    try:
-        audit_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    except OSError as exc:
-        raise AuditWriteError(path=audit_path, cause=exc) from exc
+    # left alone (``exist_ok=True``). Failures (PermissionError, etc.)
+    # propagate per fail-closed contract.
+    audit_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
 
     # ``O_APPEND`` gives atomic concurrent appends; ``O_CREAT`` handles the
-    # first call; ``0o600`` keeps the file owner-only.
-    fd = -1
+    # first call; ``0o600`` keeps the file owner-only. No try/except — any
+    # ``OSError`` from ``os.write`` / ``os.fsync`` propagates so the caller
+    # drops the partial record. The ``try / finally`` only guarantees the
+    # descriptor is released; it does NOT silence the syscall failures.
+    fd = os.open(str(audit_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
     try:
-        fd = os.open(str(audit_path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
-        os.write(fd, encoded)
+        # ``os.write`` may return fewer bytes than requested (EINTR on a
+        # signal-interrupted call, or short writes on certain filesystems
+        # / kernels). Loop until the full payload lands; raise on a
+        # zero-byte return (disk full / unrecoverable I/O failure).
+        # POSIX atomicity for ``O_APPEND`` writes still holds at the
+        # ``write(2)`` boundary up to ``PIPE_BUF``; the loop is the
+        # documented short-write recovery, not a contract violation.
+        written = 0
+        while written < len(encoded):
+            n = os.write(fd, encoded[written:])
+            if n == 0:
+                raise OSError("os.write returned 0 — disk full or other I/O failure")
+            written += n
         os.fsync(fd)
-    except OSError as exc:
-        raise AuditWriteError(path=audit_path, cause=exc) from exc
     finally:
-        if fd >= 0:
-            # Best-effort close; the write/fsync above already succeeded
-            # (or raised), so a close failure here would only mask the
-            # real outcome.
-            with contextlib.suppress(OSError):
-                os.close(fd)
+        # Best-effort close; the write/fsync above already succeeded
+        # (or raised), so a close failure here would only mask the
+        # real outcome. Mirrors the sibling writers.
+        with contextlib.suppress(OSError):
+            os.close(fd)
 
     # ANSI-safe lazy-format summary. The summary fields are user-controlled
     # (``model_unique_id`` ultimately comes from a dbt manifest) so they

--- a/src/signalforge/safety/audit.py
+++ b/src/signalforge/safety/audit.py
@@ -8,10 +8,15 @@ without an audit trail.
 Three load-bearing properties:
 
 * **Atomic concurrent appends** (DEC-005). The writer uses ``os.open`` with
-  ``O_APPEND`` and writes the full record in a single ``os.write`` call. POSIX
-  guarantees ``write(2)`` is atomic up to ``PIPE_BUF`` (4 KiB on Linux); the
+  ``O_APPEND`` and writes the record via a short-write recovery loop. POSIX
+  guarantees ``write(2)`` is atomic for ``O_APPEND`` writes up to ``PIPE_BUF``
+  (4 KiB on Linux), so under normal operation the kernel completes the write
+  in a single syscall and concurrent writers cannot interleave. The
   module-level :data:`_AUDIT_RECORD_LIMIT_BYTES` enforces a 4000-byte cap with
-  a 96-byte margin so concurrent writers cannot interleave partial records.
+  a 96-byte margin to stay below ``PIPE_BUF``. The short-write loop is the
+  documented recovery path for ``EINTR`` (signal-interrupted) calls and
+  pathological short returns on unusual filesystems / kernels — both rare in
+  practice. Mirrors the writer shape in prune / grade / diff / draft.
 * **Fail-closed on every error** (DEC-011). ``write`` catches NO exceptions
   internally — serialisation errors, ``mkdir`` failures, ``open`` failures,
   ``write`` / ``fsync`` failures all propagate raw to the caller. The
@@ -79,12 +84,17 @@ def write(event: AuditEvent, audit_path: Path) -> None:
             or ``redactions`` count. Raised BEFORE any file is opened —
             an oversize record leaves no on-disk artefact.
         OSError: any underlying I/O failure (``PermissionError``,
-            ``FileNotFoundError``, etc.) and any JSON-encoding failure
-            (raw :class:`TypeError` / :class:`ValueError` from
-            :func:`json.dumps`) propagates raw. The caller
+            ``FileNotFoundError``, ``IsADirectoryError``, etc.) from
+            ``mkdir`` / ``os.open`` / ``os.write`` / ``os.fsync`` propagates
+            raw. The caller
             (:func:`signalforge.safety.request.build_llm_request`) wraps
             non-typed propagations as
             :class:`signalforge.safety.errors.AuditWriteError`.
+        TypeError: a JSON-encoding failure from :func:`json.dumps` (e.g. an
+            unserialisable smuggled type) propagates raw. Same orchestrator
+            wrap as ``OSError``.
+        ValueError: same as ``TypeError`` — any other
+            :func:`json.dumps` failure mode propagates raw.
     """
     # Local import keeps ``audit`` importable without forcing the errors module
     # at module-eval time and matches the style used elsewhere in the package.

--- a/src/signalforge/safety/request.py
+++ b/src/signalforge/safety/request.py
@@ -45,7 +45,11 @@ import signalforge as _sf
 from signalforge.manifest.models import Model
 from signalforge.safety import audit
 from signalforge.safety.aggregate import aggregate_columns
-from signalforge.safety.errors import InvalidSamplingModeError
+from signalforge.safety.errors import (
+    AuditRecordTooLargeError,
+    AuditWriteError,
+    InvalidSamplingModeError,
+)
 from signalforge.safety.models import (
     AuditEvent,
     LLMRequest,
@@ -210,7 +214,11 @@ def build_llm_request(
 
     # ---- 4. Build the request, then audit, then return ----------------------
     # DEC-011 fail-closed: ``audit.write`` runs BEFORE we hand back the
-    # request. Any exception propagates and the request is dropped.
+    # request. ``write`` catches NO exceptions internally (mirrors the
+    # writer shape in prune/draft/grade/diff); the orchestrator owns the
+    # typed wrap. ``AuditRecordTooLargeError`` propagates as-is (already
+    # typed); every other exception wraps as ``AuditWriteError``. The
+    # partial request never escapes on either path.
     request = LLMRequest(
         model_unique_id=model.unique_id,
         mode=policy.mode,
@@ -220,7 +228,18 @@ def build_llm_request(
         aggregates=aggregates,
         schema=schema,
     )
-    audit.write(event, policy.audit_path)
+    try:
+        audit.write(event, policy.audit_path)
+    except AuditRecordTooLargeError:
+        # Already a typed safety error — propagate so downstream
+        # pattern-matching can branch on it.
+        raise
+    except (KeyboardInterrupt, SystemExit):
+        # Signal-shaped exits must propagate untouched — wrapping them
+        # would silently demote a Ctrl-C into an audit error.
+        raise
+    except BaseException as exc:
+        raise AuditWriteError(path=policy.audit_path, cause=exc) from exc
     return request
 
 

--- a/tests/draft/test_audit.py
+++ b/tests/draft/test_audit.py
@@ -289,6 +289,26 @@ def test_write_response_event_permission_denied_propagates(tmp_path: Path) -> No
         locked.chmod(0o700)
 
 
+def test_write_response_event_zero_bytes_raises_os_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero-byte return from ``os.write`` indicates an unrecoverable
+    I/O failure (disk full, etc.) — the writer raises ``OSError``
+    rather than spinning forever. Mirrors the diff sidecar's
+    ``test_write_sidecar_short_write_zero_bytes_raises`` and safety's
+    ``test_audit_write_zero_bytes_raises_os_error``.
+    """
+    audit_path = tmp_path / "response_audit.jsonl"
+
+    def zero_write(fd: int, data: bytes) -> int:
+        return 0
+
+    monkeypatch.setattr("signalforge.draft.audit.os.write", zero_write)
+    with pytest.raises(OSError, match="os.write returned 0"):
+        write_response_event(_make_event(), audit_path=audit_path)
+
+
 # --------------------------------------------------------------------------- #
 # Two-call append (sanity that JSONL accumulates rather than overwrites)
 # --------------------------------------------------------------------------- #

--- a/tests/safety/test_audit.py
+++ b/tests/safety/test_audit.py
@@ -239,6 +239,25 @@ def test_audit_write_serialisation_failure_propagates_raw(
         write(_make_event(), audit_path)
 
 
+def test_audit_write_zero_bytes_raises_os_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero-byte return from ``os.write`` indicates an unrecoverable
+    I/O failure (disk full, etc.) — the writer raises ``OSError``
+    rather than spinning forever. Mirrors the diff sidecar's
+    ``test_write_sidecar_short_write_zero_bytes_raises``.
+    """
+    audit_path = tmp_path / "audit.jsonl"
+
+    def zero_write(fd: int, data: bytes) -> int:
+        return 0
+
+    monkeypatch.setattr("signalforge.safety.audit.os.write", zero_write)
+    with pytest.raises(OSError, match="os.write returned 0"):
+        write(_make_event(), audit_path)
+
+
 def test_audit_write_fsyncs_before_close(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/safety/test_audit.py
+++ b/tests/safety/test_audit.py
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 
 from signalforge.safety.audit import write
-from signalforge.safety.errors import AuditRecordTooLargeError, AuditWriteError
+from signalforge.safety.errors import AuditRecordTooLargeError
 from signalforge.safety.models import AuditEvent, SamplingMode
 
 pytestmark = pytest.mark.safety
@@ -132,9 +132,17 @@ def test_audit_write_logger_message_escapes_ansi_in_user_input(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only permission semantics")
-def test_audit_write_failure_on_unwritable_parent_raises_audit_write_error(
+def test_audit_write_failure_on_unwritable_parent_propagates_raw(
     tmp_path: Path,
 ) -> None:
+    """A ``PermissionError`` on the parent dir propagates raw (fail-closed).
+
+    Mirrors :func:`tests.draft.test_audit.test_write_response_event_permission_denied_propagates`:
+    ``write`` catches NO exceptions internally, so the underlying
+    ``OSError`` / ``PermissionError`` propagates to the caller
+    (``build_llm_request`` in US-010) which wraps it as
+    :class:`AuditWriteError`.
+    """
     # Skip when running as root because root bypasses permission checks.
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("root bypasses POSIX permission checks")
@@ -144,9 +152,8 @@ def test_audit_write_failure_on_unwritable_parent_raises_audit_write_error(
     audit_path = locked / "denied" / "audit.jsonl"
     locked.chmod(0o000)
     try:
-        with pytest.raises(AuditWriteError) as excinfo:
+        with pytest.raises(PermissionError):
             write(_make_event(), audit_path)
-        assert isinstance(excinfo.value.cause, OSError)
     finally:
         # Restore so tmp_path cleanup can succeed.
         locked.chmod(0o700)
@@ -199,21 +206,28 @@ def test_audit_write_does_not_swallow_exceptions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """``write`` propagates the raw ``OSError`` from ``os.write`` — the
+    fail-closed contract is that the writer never wraps. The orchestrator
+    (``build_llm_request``) owns the typed wrap.
+    """
     audit_path = tmp_path / "audit.jsonl"
 
     def boom(fd: int, data: bytes) -> int:  # pragma: no cover - patched out
         raise OSError("simulated write failure")
 
     monkeypatch.setattr("signalforge.safety.audit.os.write", boom)
-    with pytest.raises(AuditWriteError) as excinfo:
+    with pytest.raises(OSError, match="simulated write failure"):
         write(_make_event(), audit_path)
-    assert isinstance(excinfo.value.cause, OSError)
 
 
-def test_audit_write_serialisation_failure_propagates_as_audit_write_error(
+def test_audit_write_serialisation_failure_propagates_raw(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A ``json.dumps`` failure propagates raw — same fail-closed
+    contract as the I/O syscalls. The orchestrator wraps; the writer
+    does not.
+    """
     audit_path = tmp_path / "audit.jsonl"
 
     def boom(*_args: Any, **_kwargs: Any) -> str:
@@ -221,9 +235,8 @@ def test_audit_write_serialisation_failure_propagates_as_audit_write_error(
 
     # Force the json.dumps call inside audit.write to fail.
     monkeypatch.setattr("signalforge.safety.audit.json.dumps", boom)
-    with pytest.raises(AuditWriteError) as excinfo:
+    with pytest.raises(TypeError, match="simulated json failure"):
         write(_make_event(), audit_path)
-    assert isinstance(excinfo.value.cause, TypeError)
 
 
 def test_audit_write_fsyncs_before_close(

--- a/tests/safety/test_request.py
+++ b/tests/safety/test_request.py
@@ -479,6 +479,24 @@ def test_build_llm_request_audit_record_too_large_propagates_typed(
     assert excinfo.value is boom
 
 
+def test_build_llm_request_keyboard_interrupt_propagates_unwrapped(
+    customers_model: Model, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Signal-shaped exits (``KeyboardInterrupt`` / ``SystemExit``) must
+    propagate untouched — wrapping them as ``AuditWriteError`` would
+    silently demote a Ctrl-C into an audit error and bury the user's
+    intent. Mirrors the same clause in ``draft_from_request``.
+    """
+    rec = _AuditRecorder(raise_on_call=KeyboardInterrupt())
+    monkeypatch.setattr("signalforge.safety.request.audit.write", rec)
+
+    fake = FakeAdapter()
+    policy = _policy(tmp_path, mode=SamplingMode.SCHEMA_ONLY)
+
+    with pytest.raises(KeyboardInterrupt):
+        build_llm_request(customers_model, fake, policy)
+
+
 # ---------------------------------------------------------------------------
 # Immutability (DEC-022) and shape invariants
 # ---------------------------------------------------------------------------

--- a/tests/safety/test_request.py
+++ b/tests/safety/test_request.py
@@ -420,6 +420,65 @@ def test_build_llm_request_audit_write_failure_raises_audit_write_error_no_reque
         build_llm_request(customers_model, fake, policy)
 
 
+def test_build_llm_request_wraps_raw_oserror_as_audit_write_error(
+    customers_model: Model, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #38 — the writer propagates raw exceptions; the orchestrator
+    owns the typed wrap.
+
+    Mirrors ``draft_from_request``'s wrap shape: a raw ``OSError`` from the
+    writer surfaces to the caller as ``AuditWriteError`` with ``cause`` set.
+    """
+    rec = _AuditRecorder(raise_on_call=OSError("simulated write failure"))
+    monkeypatch.setattr("signalforge.safety.request.audit.write", rec)
+
+    fake = FakeAdapter()
+    policy = _policy(tmp_path, mode=SamplingMode.SCHEMA_ONLY)
+
+    with pytest.raises(AuditWriteError) as excinfo:
+        build_llm_request(customers_model, fake, policy)
+    assert isinstance(excinfo.value.cause, OSError)
+    assert "simulated write failure" in str(excinfo.value.cause)
+
+
+def test_build_llm_request_wraps_serialisation_failure_as_audit_write_error(
+    customers_model: Model, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``TypeError`` from ``json.dumps`` inside the writer wraps as
+    ``AuditWriteError`` at the orchestrator boundary (issue #38).
+    """
+    rec = _AuditRecorder(raise_on_call=TypeError("simulated json failure"))
+    monkeypatch.setattr("signalforge.safety.request.audit.write", rec)
+
+    fake = FakeAdapter()
+    policy = _policy(tmp_path, mode=SamplingMode.SCHEMA_ONLY)
+
+    with pytest.raises(AuditWriteError) as excinfo:
+        build_llm_request(customers_model, fake, policy)
+    assert isinstance(excinfo.value.cause, TypeError)
+
+
+def test_build_llm_request_audit_record_too_large_propagates_typed(
+    customers_model: Model, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``AuditRecordTooLargeError`` is already typed and must propagate
+    as-is — the orchestrator's blanket-except clause must NOT rewrap it.
+    """
+    from signalforge.safety.errors import AuditRecordTooLargeError
+
+    boom = AuditRecordTooLargeError(size=5000, limit=4000)
+    rec = _AuditRecorder(raise_on_call=boom)
+    monkeypatch.setattr("signalforge.safety.request.audit.write", rec)
+
+    fake = FakeAdapter()
+    policy = _policy(tmp_path, mode=SamplingMode.SCHEMA_ONLY)
+
+    with pytest.raises(AuditRecordTooLargeError) as excinfo:
+        build_llm_request(customers_model, fake, policy)
+    # Same instance — not wrapped.
+    assert excinfo.value is boom
+
+
 # ---------------------------------------------------------------------------
 # Immutability (DEC-022) and shape invariants
 # ---------------------------------------------------------------------------

--- a/tests/test_audit_completeness.py
+++ b/tests/test_audit_completeness.py
@@ -620,11 +620,13 @@ def test_scan_7_discovers_every_per_stage_errors_module() -> None:
 # ---------------------------------------------------------------------------
 
 
-# Each entry is a writer module (relative to ``src/signalforge/``); each
-# module must contain exactly one ``Try`` block guarding ``os.write`` /
-# ``os.fsync`` calls — the ``try / finally`` around ``os.close(fd)``.
-# ``grade/audit.py`` ships two such blocks because it has two writer
-# functions (``write_grade_event`` + ``write_grading_report``).
+# Each entry is ``(relative_module_path, expected_writer_count)`` —
+# ``expected_writer_count`` is the number of writer functions in the
+# module. One writer function contributes exactly one canonical
+# ``Try`` block (``try / finally`` around ``os.close(fd)``) and exactly
+# one ``While`` loop wrapping ``os.write``, so the same count is used
+# by both Scan 8 tests. ``grade/audit.py`` is the only module with
+# more than one writer (``write_grade_event`` + ``write_grading_report``).
 _FAIL_CLOSED_WRITER_MODULES: tuple[tuple[str, int], ...] = (
     ("safety/audit.py", 1),
     ("draft/audit.py", 1),
@@ -635,8 +637,16 @@ _FAIL_CLOSED_WRITER_MODULES: tuple[tuple[str, int], ...] = (
 
 
 def _body_calls_os_syscall(body: list[ast.stmt], names: tuple[str, ...]) -> bool:
-    """Return True iff any node inside ``body`` issues a top-level
+    """Return True iff any node anywhere under ``body`` issues an
     ``os.<name>`` call (``os.write``, ``os.fsync``).
+
+    Walks the full AST under each statement in ``body`` (via
+    :func:`ast.walk`), so nested calls inside an ``if`` / ``while`` /
+    ``try`` body also match — that's load-bearing for Scan 8 because the
+    canonical writer wraps ``os.write`` inside a ``while`` loop AND the
+    ``Try`` block guards both ``os.write`` (inside the loop) and a
+    sibling ``os.fsync``. A shallow scan would miss the wrapped
+    ``os.write`` and undercount the syscalls.
     """
     for node in body:
         for sub in ast.walk(node):
@@ -669,7 +679,7 @@ def test_fail_closed_writers_have_no_except_around_write_fsync() -> None:
     """
     syscall_names = ("write", "fsync")
     failures: list[str] = []
-    for rel_path, expected_try_count in _FAIL_CLOSED_WRITER_MODULES:
+    for rel_path, expected_writer_count in _FAIL_CLOSED_WRITER_MODULES:
         module_path = _SIGNALFORGE_DIR / rel_path
         tree = ast.parse(module_path.read_text(encoding="utf-8"))
 
@@ -683,10 +693,13 @@ def test_fail_closed_writers_have_no_except_around_write_fsync() -> None:
                 if node.handlers:
                     offending.append(node.lineno)
 
-        if syscall_try_count != expected_try_count:
+        # One canonical ``Try`` (``try / finally`` around ``os.close``)
+        # per writer function in the module.
+        if syscall_try_count != expected_writer_count:
             failures.append(
-                f"{rel_path}: expected {expected_try_count} Try block(s) "
-                f"guarding os.write/os.fsync; found {syscall_try_count}."
+                f"{rel_path}: expected {expected_writer_count} Try block(s) "
+                f"guarding os.write/os.fsync (one per writer function); "
+                f"found {syscall_try_count}."
             )
         if offending:
             failures.append(
@@ -712,7 +725,7 @@ def test_fail_closed_writers_use_short_write_loop() -> None:
     functions and contains two such blocks.
     """
     failures: list[str] = []
-    for rel_path, expected_try_count in _FAIL_CLOSED_WRITER_MODULES:
+    for rel_path, expected_writer_count in _FAIL_CLOSED_WRITER_MODULES:
         module_path = _SIGNALFORGE_DIR / rel_path
         tree = ast.parse(module_path.read_text(encoding="utf-8"))
 
@@ -723,9 +736,10 @@ def test_fail_closed_writers_use_short_write_loop() -> None:
             if _body_calls_os_syscall(node.body, ("write",)):
                 looped_write_count += 1
 
-        if looped_write_count < expected_try_count:
+        # One short-write ``While`` loop per writer function.
+        if looped_write_count < expected_writer_count:
             failures.append(
-                f"{rel_path}: expected at least {expected_try_count} short-write "
+                f"{rel_path}: expected at least {expected_writer_count} short-write "
                 f"loop(s) (one per writer function); found {looped_write_count}. "
                 f"A single unlooped os.write can produce a partial JSONL record "
                 f"under EINTR / short-write conditions."

--- a/tests/test_audit_completeness.py
+++ b/tests/test_audit_completeness.py
@@ -19,6 +19,11 @@ this module adds the remaining scans:
   :data:`signalforge.cli._helpers._EXCEPTION_TO_EXIT_CODE` — the
   load-bearing test that turns the four-tier exit-code taxonomy from a
   guideline into a contract (DEC-024 of #9).
+* **Scan 8** — fail-closed writer shape across the five audit/sidecar
+  writer modules (issue #38). No ``except`` handler may wrap a ``Try``
+  whose body issues ``os.write`` / ``os.fsync``; every writer function
+  must use a short-write loop. The propagation IS the defence
+  (safety-layer.md DEC-011, repeated in prune/grade/diff rules).
 
 Each scan is its own test with an explicit, justified exclusion list. The
 scans are deterministic and cheap: each ``.py`` is read once via
@@ -606,6 +611,130 @@ def test_scan_7_discovers_every_per_stage_errors_module() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Scan 8 — fail-closed writer shape across all six audit/sidecar writers
+# (issue #38). Mirrors the AST defence in
+# ``tests/diff/test_sidecar.py::test_sidecar_module_no_except_handler_around_write_fsync``
+# but generalises it to every writer module: no ``except`` handler may wrap a
+# ``Try`` block whose body issues ``os.write`` / ``os.fsync``. The propagation
+# IS the defence (safety-layer.md DEC-011, repeated in prune/grade/diff rules).
+# ---------------------------------------------------------------------------
+
+
+# Each entry is a writer module (relative to ``src/signalforge/``); each
+# module must contain exactly one ``Try`` block guarding ``os.write`` /
+# ``os.fsync`` calls — the ``try / finally`` around ``os.close(fd)``.
+# ``grade/audit.py`` ships two such blocks because it has two writer
+# functions (``write_grade_event`` + ``write_grading_report``).
+_FAIL_CLOSED_WRITER_MODULES: tuple[tuple[str, int], ...] = (
+    ("safety/audit.py", 1),
+    ("draft/audit.py", 1),
+    ("prune/audit.py", 1),
+    ("grade/audit.py", 2),
+    ("diff/_sidecar.py", 1),
+)
+
+
+def _body_calls_os_syscall(body: list[ast.stmt], names: tuple[str, ...]) -> bool:
+    """Return True iff any node inside ``body`` issues a top-level
+    ``os.<name>`` call (``os.write``, ``os.fsync``).
+    """
+    for node in body:
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and isinstance(sub.func.value, ast.Name)
+                and sub.func.value.id == "os"
+                and sub.func.attr in names
+            ):
+                return True
+    return False
+
+
+def test_fail_closed_writers_have_no_except_around_write_fsync() -> None:
+    """Issue #38 — every fail-closed writer module must propagate raw
+    exceptions from ``os.write`` / ``os.fsync``. Any ``ast.Try`` whose body
+    issues an ``os.write`` or ``os.fsync`` call must have ``handlers == []``
+    (only ``finally`` is permitted, for the descriptor release).
+
+    A ``try / except OSError`` around the syscalls would silently swallow
+    the exact failure mode the fail-closed pattern exists to surface. The
+    typed wrap belongs at the orchestrator boundary
+    (``build_llm_request``, ``draft_from_request``, ``prune_tests``,
+    ``grade_artifacts``, ``render_diff``), not inside the writer.
+
+    Generalises the single-module scan from
+    ``tests/diff/test_sidecar.py::test_sidecar_module_no_except_handler_around_write_fsync``
+    to all five writer modules (six writer functions across them).
+    """
+    syscall_names = ("write", "fsync")
+    failures: list[str] = []
+    for rel_path, expected_try_count in _FAIL_CLOSED_WRITER_MODULES:
+        module_path = _SIGNALFORGE_DIR / rel_path
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+
+        offending: list[int] = []
+        syscall_try_count = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            if _body_calls_os_syscall(node.body, syscall_names):
+                syscall_try_count += 1
+                if node.handlers:
+                    offending.append(node.lineno)
+
+        if syscall_try_count != expected_try_count:
+            failures.append(
+                f"{rel_path}: expected {expected_try_count} Try block(s) "
+                f"guarding os.write/os.fsync; found {syscall_try_count}."
+            )
+        if offending:
+            failures.append(
+                f"{rel_path}: found except-handler(s) around os.write/os.fsync at "
+                f"line(s) {offending}. The fail-closed contract requires "
+                f"propagation, not suppression — only `try / finally` for "
+                f"os.close is permitted around the syscalls."
+            )
+
+    assert failures == [], "\n".join(failures)
+
+
+def test_fail_closed_writers_use_short_write_loop() -> None:
+    """Issue #38 — every fail-closed writer must loop on ``os.write``
+    returns to recover from short writes (``EINTR`` on signal-interrupted
+    calls; short returns on some filesystems / kernels). A single
+    unlooped ``os.write`` can theoretically produce a partial JSONL
+    record under signal-interruption load.
+
+    Detection heuristic: an ``ast.While`` whose body issues an
+    ``os.write`` call. Each writer module must contain at least one
+    such ``While`` block. The ``grade/audit.py`` module has two writer
+    functions and contains two such blocks.
+    """
+    failures: list[str] = []
+    for rel_path, expected_try_count in _FAIL_CLOSED_WRITER_MODULES:
+        module_path = _SIGNALFORGE_DIR / rel_path
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+
+        looped_write_count = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.While):
+                continue
+            if _body_calls_os_syscall(node.body, ("write",)):
+                looped_write_count += 1
+
+        if looped_write_count < expected_try_count:
+            failures.append(
+                f"{rel_path}: expected at least {expected_try_count} short-write "
+                f"loop(s) (one per writer function); found {looped_write_count}. "
+                f"A single unlooped os.write can produce a partial JSONL record "
+                f"under EINTR / short-write conditions."
+            )
+
+    assert failures == [], "\n".join(failures)
+
+
+# ---------------------------------------------------------------------------
 # Negative test: confirm the AST visitors detect planted violations
 # ---------------------------------------------------------------------------
 
@@ -639,3 +768,40 @@ def test_scan_visitors_catch_planted_violations() -> None:
     grade_finder = _NameCallFinder("GradeEvent")
     grade_finder.visit(ast.parse(grade_src))
     assert len(grade_finder.calls) == 1
+
+    # Scan 8 self-check: a synthetic Try-with-except around os.write must
+    # be flagged. Guards against a future refactor that breaks
+    # ``_body_calls_os_syscall`` (e.g. via aliased imports) silently.
+    bad_src = (
+        "import os\n"
+        "def w(fd, data):\n"
+        "    try:\n"
+        "        os.write(fd, data)\n"
+        "        os.fsync(fd)\n"
+        "    except OSError:\n"
+        "        pass\n"
+    )
+    bad_tree = ast.parse(bad_src)
+    bad_count = 0
+    for node in ast.walk(bad_tree):
+        if isinstance(node, ast.Try) and _body_calls_os_syscall(node.body, ("write", "fsync")):
+            assert node.handlers != [], "Self-check: planted Try should have an except handler"
+            bad_count += 1
+    assert bad_count == 1, "Self-check: should detect exactly one offending Try"
+
+    good_src = (
+        "import os\n"
+        "def w(fd, data):\n"
+        "    try:\n"
+        "        os.write(fd, data)\n"
+        "        os.fsync(fd)\n"
+        "    finally:\n"
+        "        os.close(fd)\n"
+    )
+    good_tree = ast.parse(good_src)
+    good_count = 0
+    for node in ast.walk(good_tree):
+        if isinstance(node, ast.Try) and _body_calls_os_syscall(node.body, ("write", "fsync")):
+            assert node.handlers == [], "Self-check: canonical Try has only finally"
+            good_count += 1
+    assert good_count == 1, "Self-check: should find exactly one canonical Try"


### PR DESCRIPTION
## Summary

Aligns the safety + draft audit writers to the canonical fail-closed shape already used by prune / grade / diff. Closes #38.

- `safety/audit.py::write` — strip the three internal `try/except` wraps (`json.dumps`, `mkdir`, `os.open`/`os.write`/`os.fsync`); add the short-write loop. The writer now propagates raw `OSError` / `TypeError`; only `AuditRecordTooLargeError` (typed; pre-open) still raises from inside.
- `safety/request.py::build_llm_request` — own the typed wrap at the orchestrator boundary, matching `draft_from_request`'s shape. `AuditRecordTooLargeError` propagates as-is; everything else wraps as `AuditWriteError(cause=...)`.
- `draft/audit.py::write_response_event` — short-write loop added (no other change; the no-except shape and orchestrator wrap were already correct).
- New **Scan 8** in `tests/test_audit_completeness.py` — two parametrised AST gates across all five writer modules: (a) no `except` handler may wrap a `Try` whose body issues `os.write` / `os.fsync`; (b) every writer function must use a short-write loop. Mirrors `tests/diff/test_sidecar.py`'s single-module template, generalised to six writer functions.

Net behaviour is unchanged from the caller's perspective — the same typed errors surface at the same boundary. The implementation now matches the rule text in `.claude/rules/safety-layer.md` DEC-011 verbatim ("Catches **no** exceptions internally").

## Test plan

- [x] `ruff check . && ruff format --check . && pyright && pytest` all green locally
- [x] 1529 / 1529 tests pass; coverage 95.14% (≥ 80% floor)
- [x] Three reframed safety writer-level tests (raw exception propagation) pass
- [x] Three new orchestrator-level tests (`build_llm_request` wraps raw `OSError` / `TypeError` as `AuditWriteError`; `AuditRecordTooLargeError` propagates as-is) pass
- [x] Scan 8 self-check (planted Try-with-except) detects the violation; canonical Try-finally passes
- [ ] CI green against `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit write reliability to ensure full payload persistence under partial-write conditions and to surface write/serialization errors directly.

* **Tests**
  * Added and updated tests covering audit failure modes, zero-byte write handling, request-bound exception behavior, and end-to-end fail-closed writer guarantees.
  * Extended completeness checks to enforce fail-closed writer shape and short-write recovery across modules.

* **Documentation**
  * Documented the project-wide fail-closed writer requirements and guidance for extending them.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->