### PR TITLE
39: relax anthropic<2.0 + pin pyright (release-blocker timebombs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,15 @@ authors = [{name = "wjduenow"}]
 dependencies = [
   "google-cloud-bigquery>=3.20,<4",
   "PyYAML>=6,<7",
+  # pydantic <3: industry-standard major-pin; v3 will be a breaking change worth a deliberate bump.
   "pydantic>=2.5,<3",
-  "anthropic>=0.50,<1.0",
+  # anthropic <2.0: lock the major so a 1.x release doesn't block fresh installs without forcing a SignalForge cut.
+  "anthropic>=0.50,<2.0",
 ]
 
 [project.optional-dependencies]
-dev = ["ruff", "pyright", "pytest", "dbt-core>=1.8,<2", "types-PyYAML>=6,<7", "pytest-cov>=5.0"]
+# pyright pinned exactly: tool bumps are tested via deliberate maintainer upgrades, not CI surprise from a new release.
+dev = ["ruff", "pyright==1.1.409", "pytest", "dbt-core>=1.8,<2", "types-PyYAML>=6,<7", "pytest-cov>=5.0"]
 
 [project.scripts]
 signalforge = "signalforge.cli:main"


### PR DESCRIPTION
## Summary

- `anthropic>=0.50,<2.0` — option (a) from the issue: lock the major so an Anthropic 1.x release doesn't block fresh `pip install signalforge-dbt` resolves without a SignalForge cut.
- `pyright==1.1.409` (exact pin) — tool bumps become deliberate maintainer upgrades, not CI surprise from a new release.
- One-line comment next to each of the three pins (anthropic, pyright, plus pydantic which stays `<3` as industry-standard) explaining the rationale.

Closes #39.

## Test plan

- [x] `ruff check .` — passes
- [x] `ruff format --check .` — passes
- [x] `pyright` — 0 errors, 0 warnings
- [x] `pytest` — 1605 passed, 13 deselected; coverage 95.39%
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated project dependencies: `anthropic` expanded to support version 2.x, `pydantic` pinned to version 2.5+, and `pyright` locked to 1.1.409 for consistent development environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/68)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->