### PR TITLE
43: hoist _path_safety to layer-neutral signalforge._common

### DIFF
--- a/.claude/rules/warehouse-adapters.md
+++ b/.claude/rules/warehouse-adapters.md
@@ -114,14 +114,18 @@ User-supplied strings render via `repr()` (`_format_value` helper) in every erro
 
 `__repr__` on the adapter shows only `project` and `location` — never the underlying client, credentials object, or any token. Same DEC.
 
-## Path safety: duplicated, not extracted (US-014 decision)
+## Path safety: layer-neutral common module + per-layer wrappers (issue #43 graduation)
 
-`signalforge.warehouse._path_safety.canonicalise_path` is a near-clone of `signalforge.manifest.loader._canonicalise_path`. The two copies stay decoupled:
+`signalforge._common.path_safety.canonicalise_path` is the single canonical home for the project's symlink / containment defence. It raises a project-neutral typed escape (`PathContainmentError(Exception)`) — no layer prefix, no inheritance from any stage's error hierarchy. The three traps from `manifest-readers.md` (resolve symlinks before containment check; catch `RuntimeError` on cycles; gate the *default* path through the same helper) live here.
 
-- Different escape exceptions (`ProfileNotFoundError` vs `ModelPathOutsideProjectError`) keep each layer's catch surface homogeneous — every "we couldn't load the file" condition in one layer raises one typed error.
-- A shared utility module would force every caller to translate the generic exception back to a layer-specific one, which is more code than the duplication.
+Two distinct consumer patterns:
 
-US-014 evaluated extraction; the decision is to keep the duplication explicit. Apply the three traps from `manifest-readers.md` (resolve symlinks before containment check; catch `RuntimeError` on cycles; gate the *default* path through the same helper) when adding a third copy in a new reader.
+1. **Cross-package consumers (cli / diff / grade / prune)** import `canonicalise_path` and `PathContainmentError` directly from `signalforge._common.path_safety`. At the orchestrator boundary they catch `PathContainmentError` and re-raise as their own layer-typed error (`CliPathError`, `DiffSidecarWriteError`, `GradeAuditWriteError`, `PruneAuditWriteError`) so each layer's downstream catch surface stays homogeneous — every "we couldn't durably persist X" condition in one layer raises one typed error.
+2. **Layer wrappers (`warehouse/_path_safety.py`, `safety/_path_safety.py`)** are thin shims that delegate to the common helper and translate `PathContainmentError` → the layer's typed error (`ProfileNotFoundError`, `InvalidConfigError`) at the helper level. Warehouse callers (`warehouse/profiles.py`) and safety callers (`safety/config.py`) keep their existing one-line call sites and one typed-error catch surface. The wrappers exist because every internal call site within those layers wants the same translation; pushing the try/except into every caller would be more code than the shim.
+
+The manifest loader still ships its own `_canonicalise_path` helper inline — manifest predates the common module and its escape exception (`ModelPathOutsideProjectError`) is tied tightly to the loader's diagnostic shape. Promotion is a future-clean-up candidate; the cost/benefit is low until a third consumer wants to share manifest's behaviour.
+
+When introducing a new stage that needs path canonicalisation, prefer pattern (1) — import from `_common.path_safety` directly, wrap at the orchestrator. Reach for pattern (2) only when the layer has many internal callers that all want the same typed-error translation. **Don't** create a new layer-local `_path_safety.py` that duplicates the helper's body — that's the historical mistake issue #43 reverses.
 
 ## No logging in stage-0 modules; one-line warnings only at adapter boundary
 

--- a/src/signalforge/_common/__init__.py
+++ b/src/signalforge/_common/__init__.py
@@ -1,7 +1,13 @@
 """Layer-neutral helpers shared across pipeline stages.
 
-Modules under :mod:`signalforge._common` raise plain :class:`ValueError`
-on bad input and never depend on a layer-specific error hierarchy.
-Consumers in :mod:`signalforge.grade` and :mod:`signalforge.diff` import
-from here directly; the public-API surface lives on the consuming layer.
+Modules under :mod:`signalforge._common` never depend on a layer-specific
+error hierarchy. Programming-error guards raise plain :class:`ValueError`;
+recurrent typed conditions (e.g. path-containment failure) raise a
+project-neutral typed exception defined alongside the helper (see
+:class:`signalforge._common.path_safety.PathContainmentError`).
+
+Cross-layer consumers import from here directly; the public-API surface
+lives on the consuming layer, which catches the layer-neutral typed
+exception at its orchestrator boundary and re-raises as its own typed
+error so the layer's catch surface stays homogeneous.
 """

--- a/src/signalforge/_common/path_safety.py
+++ b/src/signalforge/_common/path_safety.py
@@ -1,0 +1,81 @@
+"""Layer-neutral symlink-hardened path canonicalisation.
+
+This module is the single canonical home for the project's symlink /
+containment defence (the three traps from ``.claude/rules/manifest-readers.md``).
+Layers (warehouse, safety, cli, diff, grade, prune) call into here directly
+and either catch :class:`PathContainmentError` to re-raise as their own
+layer-typed error, or let it propagate to a single boundary catch.
+
+Before issue #43, every cross-package consumer imported
+``signalforge.warehouse._path_safety.canonicalise_path`` and pattern-matched on
+:class:`signalforge.warehouse.errors.ProfileNotFoundError`. The warehouse name
+leaked into grade/diff/prune/cli audit-write paths — a stack trace from a
+grade-layer audit write surfaced a warehouse-profile error class. This module
+fixes that by exposing a project-neutral typed escape that no layer owns.
+
+The three traps preserved here:
+
+1. Resolve symlinks before checking containment
+   (:meth:`pathlib.Path.relative_to` does **not** follow symlinks).
+2. Catch :class:`RuntimeError` from :meth:`pathlib.Path.resolve` — it raises
+   on symlink cycles regardless of the ``strict=`` flag.
+3. Apply the same gate to the *default* path the caller chooses, not just to
+   user-supplied overrides — convention is not a security boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class PathContainmentError(Exception):
+    """Raised when a path fails symlink-hardened canonicalisation.
+
+    Layer-neutral typed escape so non-warehouse consumers (cli / diff /
+    grade / prune) can catch this at their orchestrator boundary and
+    re-raise as their own layer-typed error without importing a
+    warehouse-layer name.
+
+    The exception message identifies the specific failure mode (loop,
+    missing directory, escape from ``project_dir``); callers that need to
+    translate to a layer-typed remediation can use the message verbatim or
+    paraphrase it.
+    """
+
+
+def canonicalise_path(input_path: Path | str, project_dir: Path) -> Path:
+    """Resolve ``input_path`` to an absolute path inside ``project_dir``'s tree.
+
+    Both the input path and ``project_dir`` are run through
+    :meth:`pathlib.Path.resolve` so symlinks are followed before the
+    containment check. The default-path argument the caller supplies must
+    flow through this helper too — the hardening only holds when both
+    user-supplied and default paths use the same gate.
+
+    Raises:
+        PathContainmentError: when the resolved path escapes
+            ``project_dir`` (so a symlink pointing at ``/etc/passwd`` cannot
+            be reached via a relative input), when either path traverses a
+            symlink cycle (``Path.resolve`` raises :class:`RuntimeError` on
+            cycles regardless of ``strict=``), or when ``project_dir``
+            itself does not exist or is not a directory.
+    """
+    p = Path(input_path)
+    try:
+        project_resolved = project_dir.resolve(strict=True)
+    except RuntimeError as exc:
+        raise PathContainmentError(f"project_dir {project_dir} contains a symlink loop") from exc
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        raise PathContainmentError(
+            f"project_dir {project_dir} does not exist or is not a directory"
+        ) from exc
+
+    if not p.is_absolute():
+        p = project_resolved / p
+    try:
+        resolved = p.resolve(strict=False)
+    except RuntimeError as exc:
+        raise PathContainmentError(f"path {p} contains a symlink loop") from exc
+    if not resolved.is_relative_to(project_resolved):
+        raise PathContainmentError(f"path {resolved} escapes project_dir {project_resolved}")
+    return resolved

--- a/src/signalforge/_common/path_safety.py
+++ b/src/signalforge/_common/path_safety.py
@@ -69,6 +69,13 @@ def canonicalise_path(input_path: Path | str, project_dir: Path) -> Path:
         raise PathContainmentError(
             f"project_dir {project_dir} does not exist or is not a directory"
         ) from exc
+    # `Path.resolve(strict=True)` succeeds on an existing regular file, so the
+    # "is not a directory" promise in the docstring would silently break for a
+    # bare-file `project_dir` (caught by Copilot on PR #72). Explicit guard:
+    if not project_resolved.is_dir():
+        raise PathContainmentError(
+            f"project_dir {project_dir} does not exist or is not a directory"
+        )
 
     if not p.is_absolute():
         p = project_resolved / p

--- a/src/signalforge/cli/_helpers.py
+++ b/src/signalforge/cli/_helpers.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     # private ``_BatchOutcome`` dataclass shape only at type-check time.
     from signalforge.cli.generate import _BatchOutcome
 
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
 from signalforge.cli.errors import (
     CliError,
     CliInputError,
@@ -146,7 +147,6 @@ from signalforge.warehouse import (
     WarehouseAuthError,
     WarehouseError,
 )
-from signalforge.warehouse._path_safety import canonicalise_path
 
 __all__ = [
     "canonicalise_user_path",
@@ -357,13 +357,13 @@ def map_exception_to_exit_code(exc: BaseException) -> int:
 
 
 def canonicalise_user_path(raw: str | Path | None, project_dir: Path) -> Path | None:
-    """Wrap :func:`signalforge.warehouse._path_safety.canonicalise_path`
+    """Wrap :func:`signalforge._common.path_safety.canonicalise_path`
     with a CLI-layer error type and a ``None`` passthrough.
 
     Returns ``None`` when ``raw`` is ``None`` so callers can express
     optional-flag plumbing without a per-call ``if`` ladder.
 
-    The wrapped helper raises :class:`ProfileNotFoundError` on its
+    The wrapped helper raises :class:`PathContainmentError` on its
     failure modes (symlink loop, escape from ``project_dir``, missing
     project directory). We re-raise as :class:`CliPathError` so the
     CLI's own try/except boundary gets a homogeneous catch surface —
@@ -374,7 +374,7 @@ def canonicalise_user_path(raw: str | Path | None, project_dir: Path) -> Path | 
         return None
     try:
         return canonicalise_path(raw, project_dir)
-    except Exception as exc:  # noqa: BLE001
+    except PathContainmentError as exc:
         raise CliPathError(
             f"path {raw!r} failed safety check: {exc}",
             remediation=(

--- a/src/signalforge/diff/_sidecar.py
+++ b/src/signalforge/diff/_sidecar.py
@@ -37,8 +37,8 @@ sidecar precedent:
   than evidence-only payloads (DEC-009 of #8).
 
 The path-safety gate at writer entry routes ``sidecar_path`` through
-:func:`signalforge.warehouse._path_safety.canonicalise_path`, the
-project's standard symlink/containment helper. A symlink at
+:func:`signalforge._common.path_safety.canonicalise_path`, the project's
+standard symlink/containment helper. A symlink at
 ``<project>/.signalforge/diff.json`` pointing outside the project tree
 is rejected — the writer refuses rather than write outside the project
 sandbox. Mirrors prune's post-QG fix and grade's writer-entry
@@ -52,10 +52,9 @@ import os
 from pathlib import Path
 from typing import Final
 
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
 from signalforge.diff.errors import DiffSidecarRecordTooLargeError, DiffSidecarWriteError
 from signalforge.diff.models import DiffReport
-from signalforge.warehouse._path_safety import canonicalise_path
-from signalforge.warehouse.errors import ProfileNotFoundError
 
 # DEC-009 of #8 — 10 MB cap, an order of magnitude above the grade
 # sidecar's 1 MB cap because diff text (unified diffs across thousands of
@@ -102,12 +101,13 @@ def write_sidecar(
        artefact.
     4. **Path canonicalisation BEFORE any file open**: route
        ``sidecar_path`` through
-       :func:`signalforge.warehouse._path_safety.canonicalise_path` with
-       the caller-supplied ``project_dir``. A symlink escape or cycle is
+       :func:`signalforge._common.path_safety.canonicalise_path` with the
+       caller-supplied ``project_dir``. A symlink escape or cycle is
        wrapped as :class:`DiffSidecarWriteError` — this is the only place
        the writer wraps an exception, because the path-safety helper
-       raises :class:`ProfileNotFoundError` (a warehouse-layer error name
-       that would be confusing for diff callers).
+       raises a layer-neutral :class:`PathContainmentError` and the
+       diff layer surfaces its own typed error to keep its catch
+       surface homogeneous.
     5. Ensure the parent directory exists (``mkdir(parents=True,
        exist_ok=True)``) BEFORE the ``os.open`` so the orchestrator can
        call us against a fresh ``.signalforge/`` directory.
@@ -138,7 +138,7 @@ def write_sidecar(
             artefact.
         DiffSidecarWriteError: ``sidecar_path`` escapes ``project_dir``
             (symlink) or contains a symlink cycle. The original
-            :class:`signalforge.warehouse.errors.ProfileNotFoundError`
+            :class:`signalforge._common.path_safety.PathContainmentError`
             is preserved as ``__cause__`` / ``cause``.
         OSError: any underlying I/O failure on the open / write / fsync
             (``PermissionError``, ``FileNotFoundError``, etc.) propagates
@@ -175,7 +175,8 @@ def write_sidecar(
     # true project root; deriving it from ``sidecar_path.parent.parent``
     # would let an absolute caller-supplied path slip the gate). A
     # symlink escape or cycle in the helper raises
-    # ``ProfileNotFoundError`` (the warehouse-layer name); wrap into a
+    # ``PathContainmentError`` (layer-neutral, from
+    # :mod:`signalforge._common.path_safety`); wrap into a
     # ``DiffSidecarWriteError`` so callers branch on one diff-layer
     # error class. This is the ONLY exception wrap the writer performs
     # — non-path I/O failures propagate raw.
@@ -183,7 +184,7 @@ def write_sidecar(
     project_dir = Path(project_dir)
     try:
         canonical_path = canonicalise_path(sidecar_path, project_dir=project_dir)
-    except ProfileNotFoundError as exc:
+    except PathContainmentError as exc:
         raise DiffSidecarWriteError(
             f"Diff sidecar path {sidecar_path!r} failed symlink/containment validation.",
             cause=exc,

--- a/src/signalforge/diff/config.py
+++ b/src/signalforge/diff/config.py
@@ -60,9 +60,8 @@ from typing import Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
 from signalforge.diff.errors import DiffError
-from signalforge.warehouse._path_safety import canonicalise_path
-from signalforge.warehouse.errors import ProfileNotFoundError
 
 _DEFAULT_CONFIG_FILENAME = "signalforge.yml"
 
@@ -260,7 +259,7 @@ def load_diff_config(project_dir: Path, path: Path | None = None) -> DiffConfig:
     # :meth:`pathlib.Path.read_text`.
     try:
         canonical = canonicalise_path(config_file, project_dir)
-    except ProfileNotFoundError as exc:
+    except PathContainmentError as exc:
         raise DiffError(
             f"signalforge diff config path failed canonicalisation: {config_file!r}",
             remediation=(

--- a/src/signalforge/diff/engine.py
+++ b/src/signalforge/diff/engine.py
@@ -62,6 +62,7 @@ from pathlib import Path
 import yaml
 
 import signalforge as _sf
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
 from signalforge.diff._artifact_id import (
     _model_test_args_hash,
     artifact_id_for,
@@ -92,8 +93,6 @@ from signalforge.draft.models import (
 from signalforge.grade.models import GradingReport, GradingResult
 from signalforge.manifest.models import Model
 from signalforge.prune.models import DropReason, PruneDecision, PruneResult
-from signalforge.warehouse._path_safety import canonicalise_path
-from signalforge.warehouse.errors import ProfileNotFoundError as _PathContainmentError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1003,7 +1002,7 @@ def render_diff(
             ) from exc
         try:
             canonical_output_path = canonicalise_path(output_path, resolved_project_dir)
-        except _PathContainmentError as exc:
+        except PathContainmentError as exc:
             raise DiffSidecarWriteError(
                 f"Diff output path {output_path!r} failed symlink/containment validation.",
                 cause=exc,
@@ -1049,7 +1048,7 @@ def render_diff(
             ) from exc
         try:
             canonical_sidecar_path = canonicalise_path(effective_sidecar_path, resolved_project_dir)
-        except _PathContainmentError as exc:
+        except PathContainmentError as exc:
             raise DiffSidecarWriteError(
                 f"Diff sidecar path {effective_sidecar_path!r} "
                 f"failed symlink/containment validation.",

--- a/src/signalforge/grade/audit.py
+++ b/src/signalforge/grade/audit.py
@@ -38,8 +38,8 @@ draft, and prune layers:
   calls anywhere else once US-009 lands.
 
 The path-safety gate at writer entry routes ``audit_path`` through
-:func:`signalforge.warehouse._path_safety.canonicalise_path`, the
-project's standard symlink/containment helper. A symlink at
+:func:`signalforge._common.path_safety.canonicalise_path`, the project's
+standard symlink/containment helper. A symlink at
 ``<project>/.signalforge/grade.jsonl`` pointing outside the project
 tree is rejected — the writer refuses rather than write outside the
 project sandbox. Mirrors prune's post-QG fix.
@@ -55,10 +55,9 @@ from pathlib import Path
 from typing import Final
 
 from signalforge import __version__ as _SIGNALFORGE_VERSION
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
 from signalforge.grade.errors import GradeAuditRecordTooLargeError, GradeAuditWriteError
 from signalforge.grade.models import GradeEvent, GradingReport
-from signalforge.warehouse._path_safety import canonicalise_path
-from signalforge.warehouse.errors import ProfileNotFoundError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -158,14 +157,14 @@ def write_grade_event(event: GradeEvent, *, audit_path: Path) -> None:
        artefact.
     4. **Path canonicalisation BEFORE any file open**: route
        ``audit_path`` through
-       :func:`signalforge.warehouse._path_safety.canonicalise_path` with
+       :func:`signalforge._common.path_safety.canonicalise_path` with
        ``project_dir=audit_path.parent.parent`` (the audit log lives at
        ``<project>/.signalforge/grade.jsonl`` per DEC-006). A symlink
        escape or cycle is wrapped as :class:`GradeAuditWriteError` —
        this is the only place the writer wraps an exception, because the
-       path-safety helper raises :class:`ProfileNotFoundError` (a
-       warehouse-layer error name that would be confusing for grade
-       callers).
+       path-safety helper raises a layer-neutral
+       :class:`PathContainmentError` and the grade layer surfaces its own
+       typed error to keep its catch surface homogeneous.
     5. Ensure the parent directory exists (``mkdir(parents=True,
        exist_ok=True)``) BEFORE the ``os.open`` so the orchestrator can
        call us against a fresh ``.signalforge/`` directory.
@@ -189,7 +188,7 @@ def write_grade_event(event: GradeEvent, *, audit_path: Path) -> None:
             artefact.
         GradeAuditWriteError: ``audit_path`` escapes the project tree
             (symlink) or contains a symlink cycle. The original
-            :class:`signalforge.warehouse.errors.ProfileNotFoundError`
+            :class:`signalforge._common.path_safety.PathContainmentError`
             is preserved as ``__cause__`` / ``cause``.
         OSError: any underlying I/O failure on the open / write / fsync
             (``PermissionError``, ``FileNotFoundError``, etc.) propagates
@@ -215,15 +214,16 @@ def write_grade_event(event: GradeEvent, *, audit_path: Path) -> None:
     # Path canonicalisation BEFORE any file open. The audit log lives at
     # ``<project>/.signalforge/grade.jsonl`` per DEC-006, so the project
     # dir is ``audit_path.parent.parent``. A symlink escape or cycle in
-    # the helper raises ``ProfileNotFoundError`` (the warehouse-layer
-    # name); wrap into a ``GradeAuditWriteError`` so callers branch on
-    # one grade-layer error class. This is the ONLY exception wrap the
-    # writer performs — non-path I/O failures propagate raw.
+    # the helper raises ``PathContainmentError`` (layer-neutral, from
+    # :mod:`signalforge._common.path_safety`); wrap into a
+    # ``GradeAuditWriteError`` so callers branch on one grade-layer
+    # error class. This is the ONLY exception wrap the writer performs
+    # — non-path I/O failures propagate raw.
     audit_path = Path(audit_path)
     project_dir = audit_path.parent.parent
     try:
         canonical_path = canonicalise_path(audit_path, project_dir=project_dir)
-    except ProfileNotFoundError as exc:
+    except PathContainmentError as exc:
         raise GradeAuditWriteError(
             (f"Grade audit path {audit_path!r} failed symlink/containment validation."),
             cause=exc,
@@ -290,7 +290,7 @@ def write_grading_report(report: GradingReport, *, sidecar_path: Path) -> None:
     * Oversize → :class:`GradeAuditRecordTooLargeError` BEFORE any
       file open. No on-disk artefact.
     * Path symlink-escape / cycle → :class:`GradeAuditWriteError`
-      wrapping the underlying :class:`ProfileNotFoundError`.
+      wrapping the underlying :class:`PathContainmentError`.
     * All other I/O failures (``OSError`` /
       ``PermissionError`` / encoding failures) propagate raw — the
       orchestrator wraps them in its own :class:`GradeAuditWriteError`
@@ -323,7 +323,7 @@ def write_grading_report(report: GradingReport, *, sidecar_path: Path) -> None:
     project_dir = sidecar_path.parent.parent
     try:
         canonical_path = canonicalise_path(sidecar_path, project_dir=project_dir)
-    except ProfileNotFoundError as exc:
+    except PathContainmentError as exc:
         raise GradeAuditWriteError(
             (f"Grade sidecar path {sidecar_path!r} failed symlink/containment validation."),
             cause=exc,

--- a/src/signalforge/grade/engine.py
+++ b/src/signalforge/grade/engine.py
@@ -86,6 +86,7 @@ from signalforge._common.artifact_id import (
 from signalforge._common.artifact_id import (  # noqa: F401
     model_test_args_hash as _model_test_args_hash,
 )
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
 from signalforge.draft.models import (
     CandidateColumn,
     CandidateSchema,
@@ -126,8 +127,6 @@ from signalforge.llm.client import call_anthropic
 from signalforge.llm.errors import LLMError
 from signalforge.manifest.models import Model
 from signalforge.prune.models import PruneResult
-from signalforge.warehouse._path_safety import canonicalise_path
-from signalforge.warehouse.errors import ProfileNotFoundError as _PathContainmentError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -589,14 +588,14 @@ def grade_artifacts(
     # before any I/O, so the writer never sees an escape-attempt path.
     try:
         resolved_audit_path = canonicalise_path(raw_audit_path, resolved_project_dir)
-    except _PathContainmentError as exc:
+    except PathContainmentError as exc:
         raise GradeAuditWriteError(
             f"Grade audit path {raw_audit_path!r} failed symlink/containment validation.",
             cause=exc,
         ) from exc
     try:
         resolved_sidecar_path = canonicalise_path(raw_sidecar_path, resolved_project_dir)
-    except _PathContainmentError as exc:
+    except PathContainmentError as exc:
         raise GradeAuditWriteError(
             f"Grade sidecar path {raw_sidecar_path!r} failed symlink/containment validation.",
             cause=exc,

--- a/src/signalforge/prune/engine.py
+++ b/src/signalforge/prune/engine.py
@@ -81,6 +81,7 @@ import time
 from pathlib import Path
 
 from signalforge import __version__ as _SIGNALFORGE_VERSION
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
 from signalforge.draft.models import CandidateSchema, CandidateTest
 from signalforge.manifest.models import Manifest, Model
 from signalforge.prune.audit import (
@@ -102,9 +103,8 @@ from signalforge.prune.errors import (
     PruneTrustedModelNotFoundError,
 )
 from signalforge.prune.models import PruneDecision, PruneResult, Scope
-from signalforge.warehouse._path_safety import canonicalise_path
 from signalforge.warehouse.base import WarehouseAdapter
-from signalforge.warehouse.errors import ProfileNotFoundError, WarehouseError
+from signalforge.warehouse.errors import WarehouseError
 from signalforge.warehouse.models import TableRef, TestResult
 
 _LOGGER = logging.getLogger(__name__)
@@ -727,7 +727,7 @@ def prune_tests(
             ``project_dir`` is :func:`pathlib.Path.cwd`); the parent
             directory is created if missing. The resolved path is
             symlink-hardened via
-            :func:`signalforge.warehouse._path_safety.canonicalise_path`
+            :func:`signalforge._common.path_safety.canonicalise_path`
             before any write so a symlinked
             ``<project>/.signalforge/prune.jsonl`` cannot redirect
             writes outside the project tree (DEC-016).
@@ -787,15 +787,15 @@ def prune_tests(
     # `.signalforge/prune.jsonl` pointing outside the project tree
     # could redirect writes to an attacker-controlled location.
     # ``canonicalise_path`` requires project_dir to exist; it raises
-    # ``ProfileNotFoundError`` (the warehouse-layer escape) on cycle /
-    # missing-dir / containment-violation. Wrap as
-    # ``PruneAuditWriteError`` so the prune layer's catch surface stays
-    # homogeneous — every "we couldn't durably persist the audit"
-    # condition raises a single typed error.
+    # :class:`PathContainmentError` (layer-neutral, defined in
+    # :mod:`signalforge._common.path_safety`) on cycle / missing-dir /
+    # containment-violation. Wrap as :class:`PruneAuditWriteError` so the
+    # prune layer's catch surface stays homogeneous — every "we couldn't
+    # durably persist the audit" condition raises a single typed error.
     resolved_project_dir.mkdir(parents=True, exist_ok=True)
     try:
         resolved_audit_path = canonicalise_path(raw_audit_path, resolved_project_dir)
-    except ProfileNotFoundError as exc:
+    except PathContainmentError as exc:
         raise PruneAuditWriteError(
             "Prune-audit path failed symlink-hardened canonicalisation; "
             "refusing to write outside the project tree.",

--- a/src/signalforge/safety/_path_safety.py
+++ b/src/signalforge/safety/_path_safety.py
@@ -1,83 +1,52 @@
 """Symlink-hardened path canonicalisation for the safety subpackage.
 
-This is the safety-side counterpart to
-:func:`signalforge.warehouse._path_safety.canonicalise_path` and
-:func:`signalforge.manifest.loader._canonicalise_path`. Per the
-``warehouse-adapters.md`` rule "Path safety: duplicated, not extracted",
-each layer keeps its own copy so the layer's catch surface stays
-homogeneous: every "we couldn't load the safety config" condition raises
-:class:`signalforge.safety.errors.InvalidConfigError`.
+Thin wrapper around :func:`signalforge._common.path_safety.canonicalise_path`
+(issue #43) — the canonical home for the project's symlink / containment
+defence is now layer-neutral. This shim catches the project-neutral
+:class:`signalforge._common.path_safety.PathContainmentError` and re-raises
+as :class:`signalforge.safety.errors.InvalidConfigError` so the safety
+layer's catch surface stays homogeneous: every "we couldn't load the
+safety config" condition raises a single typed error.
 
-The three traps from ``manifest-readers.md`` apply:
-
-1. Resolve symlinks before checking containment
-   (:meth:`pathlib.Path.relative_to` does **not** follow symlinks).
-2. Catch :class:`RuntimeError` from :meth:`pathlib.Path.resolve` — it raises
-   on symlink cycles regardless of the ``strict=`` flag.
-3. Apply the same gate to the *default* path the loader chooses, not just to
-   user-supplied overrides — convention is not a security boundary.
+Per ``warehouse-adapters.md`` § "Path safety", layer-typed translation
+happens at the helper level (here) so safety callers — ``safety/config.py``
+in particular — don't carry the try/except at every call site.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from signalforge._common.path_safety import (
+    PathContainmentError,
+)
+from signalforge._common.path_safety import (
+    canonicalise_path as _common_canonicalise_path,
+)
 from signalforge.safety.errors import InvalidConfigError
 
 
 def canonicalise_path(input_path: Path | str, project_dir: Path) -> Path:
     """Resolve ``input_path`` to an absolute path inside ``project_dir``'s tree.
 
-    Both the input path and ``project_dir`` are run through
-    :meth:`pathlib.Path.resolve` so symlinks are followed before the
-    containment check. The default-path argument the caller supplies must
-    flow through this helper too — DEC-013's hardening only holds when both
-    user-supplied and default paths use the same gate.
+    Delegates to :func:`signalforge._common.path_safety.canonicalise_path`
+    and translates :class:`PathContainmentError` into
+    :class:`InvalidConfigError` so safety callers keep one typed-error
+    catch surface.
 
     Raises:
-        InvalidConfigError: when the resolved path escapes ``project_dir``
-            (so a symlink pointing at ``/etc/passwd`` cannot be reached via a
-            relative input), when either path traverses a symlink cycle
-            (``Path.resolve`` raises :class:`RuntimeError` on cycles
-            regardless of ``strict=``), or when ``project_dir`` itself does
+        InvalidConfigError: when the resolved path escapes ``project_dir``,
+            contains a symlink loop, or when ``project_dir`` itself does
             not exist or is not a directory.
     """
-    p = Path(input_path)
     try:
-        project_resolved = project_dir.resolve(strict=True)
-    except RuntimeError as exc:
+        return _common_canonicalise_path(input_path, project_dir)
+    except PathContainmentError as exc:
         raise InvalidConfigError(
-            message=f"project_dir {project_dir} contains a symlink loop",
+            message=str(exc),
             remediation=(
-                f"project_dir {project_dir} contains a symlink loop; resolve the "
-                "loop or pass a different project directory."
+                f"{exc}. audit_path must point inside the project tree "
+                "(default: .signalforge/audit.jsonl), must not traverse a "
+                "symlink loop, and project_dir must exist as a directory."
             ),
         ) from exc
-    except (FileNotFoundError, NotADirectoryError) as exc:
-        raise InvalidConfigError(
-            message=f"project_dir {project_dir} does not exist or is not a directory",
-            remediation=(f"project_dir {project_dir} does not exist or is not a directory."),
-        ) from exc
-
-    if not p.is_absolute():
-        p = project_resolved / p
-    try:
-        resolved = p.resolve(strict=False)
-    except RuntimeError as exc:
-        raise InvalidConfigError(
-            message=f"Path {p} contains a symlink loop",
-            remediation=(
-                f"Path {p} contains a symlink loop; resolve the loop or remove "
-                "the offending symlink."
-            ),
-        ) from exc
-    if not resolved.is_relative_to(project_resolved):
-        raise InvalidConfigError(
-            message=f"Path {resolved} escapes project_dir {project_resolved}",
-            remediation=(
-                f"Path {resolved} escapes project_dir {project_resolved}; "
-                "audit_path must point inside the project tree "
-                "(default: .signalforge/audit.jsonl)."
-            ),
-        )
-    return resolved

--- a/src/signalforge/warehouse/_path_safety.py
+++ b/src/signalforge/warehouse/_path_safety.py
@@ -42,8 +42,15 @@ def canonicalise_path(input_path: Path | str, project_dir: Path) -> Path:
     try:
         return _common_canonicalise_path(input_path, project_dir)
     except PathContainmentError as exc:
+        # Record the project-scoped location actually validated so the
+        # ``ProfileNotFoundError`` carries the right diagnostic (Copilot
+        # caught the regression — a relative ``input_path`` like
+        # ``"profiles.yml"`` would otherwise land as cwd-relative,
+        # losing the project_dir context).
+        raw = Path(input_path)
+        searched = raw if raw.is_absolute() else (Path(project_dir) / raw)
         raise ProfileNotFoundError(
-            searched_paths=[Path(input_path)],
+            searched_paths=[searched],
             remediation=(
                 f"{exc}. profiles.yml must point inside the project tree, "
                 "must not traverse a symlink loop, and project_dir must "

--- a/src/signalforge/warehouse/_path_safety.py
+++ b/src/signalforge/warehouse/_path_safety.py
@@ -1,84 +1,52 @@
 """Symlink-hardened path canonicalisation for the warehouse subpackage.
 
-This is the warehouse-side counterpart to
-:func:`signalforge.manifest.loader._canonicalise_path`. Per the
-:doc:`/.claude/rules/manifest-readers` rule, every reader that derives a
-filesystem path from user-supplied input must:
+Thin wrapper around :func:`signalforge._common.path_safety.canonicalise_path`
+(issue #43) — the canonical home for the project's symlink / containment
+defence is now layer-neutral. This shim catches the project-neutral
+:class:`signalforge._common.path_safety.PathContainmentError` and re-raises
+as :class:`signalforge.warehouse.errors.ProfileNotFoundError` so the
+warehouse layer's catch surface stays homogeneous: every "we couldn't load
+profiles.yml" condition raises a single typed error.
 
-1. Resolve symlinks before checking containment
-   (:meth:`pathlib.Path.relative_to` does **not** follow symlinks).
-2. Catch :class:`RuntimeError` from :meth:`pathlib.Path.resolve` — it raises
-   on symlink cycles regardless of the ``strict=`` flag.
-3. Apply the same gate to the *default* path the loader chooses, not just to
-   user-supplied overrides — convention is not a security boundary.
-
-The function is a near-clone of the manifest loader's helper. DEC-017 in the
-warehouse plan deliberately keeps the two copies decoupled rather than
-hoisting a shared helper into a utility module — promotion is a US-014
-follow-up. The escape / cycle exception is :class:`ProfileNotFoundError`
-here (instead of ``ModelPathOutsideProjectError``) so the warehouse layer's
-catch surface stays homogeneous: every "we couldn't load profiles.yml"
-condition raises a single typed error.
+Per ``warehouse-adapters.md`` § "Path safety", layer-typed translation
+happens at the helper level (here) so warehouse callers — ``profiles.py``
+in particular — don't carry the try/except at every call site.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from signalforge._common.path_safety import (
+    PathContainmentError,
+)
+from signalforge._common.path_safety import (
+    canonicalise_path as _common_canonicalise_path,
+)
 from signalforge.warehouse.errors import ProfileNotFoundError
 
 
 def canonicalise_path(input_path: Path | str, project_dir: Path) -> Path:
     """Resolve ``input_path`` to an absolute path inside ``project_dir``'s tree.
 
-    Both the input path and ``project_dir`` are run through
-    :meth:`pathlib.Path.resolve` so symlinks are followed before the
-    containment check. The default-path argument the caller supplies must
-    flow through this helper too — DEC-007's hardening only holds when both
-    user-supplied and default paths use the same gate.
+    Delegates to :func:`signalforge._common.path_safety.canonicalise_path`
+    and translates :class:`PathContainmentError` into
+    :class:`ProfileNotFoundError` so warehouse callers keep one typed-error
+    catch surface.
 
     Raises:
         ProfileNotFoundError: when the resolved path escapes
-            ``project_dir`` (so a symlink pointing at ``/etc/passwd`` cannot
-            be reached via a relative input), or when either path traverses
-            a symlink cycle (``Path.resolve`` raises :class:`RuntimeError`
-            on cycles regardless of ``strict=``).
+            ``project_dir``, contains a symlink loop, or when
+            ``project_dir`` itself does not exist or is not a directory.
     """
-    p = Path(input_path)
     try:
-        project_resolved = project_dir.resolve(strict=True)
-    except RuntimeError as exc:
+        return _common_canonicalise_path(input_path, project_dir)
+    except PathContainmentError as exc:
         raise ProfileNotFoundError(
-            searched_paths=[project_dir],
+            searched_paths=[Path(input_path)],
             remediation=(
-                f"project_dir {project_dir} contains a symlink loop; resolve the "
-                "loop or pass a different project directory."
+                f"{exc}. profiles.yml must point inside the project tree, "
+                "must not traverse a symlink loop, and project_dir must "
+                "exist as a directory."
             ),
         ) from exc
-    except (FileNotFoundError, NotADirectoryError) as exc:
-        raise ProfileNotFoundError(
-            searched_paths=[project_dir],
-            remediation=(f"project_dir {project_dir} does not exist or is not a directory."),
-        ) from exc
-
-    if not p.is_absolute():
-        p = project_resolved / p
-    try:
-        resolved = p.resolve(strict=False)
-    except RuntimeError as exc:
-        raise ProfileNotFoundError(
-            searched_paths=[p],
-            remediation=(
-                f"Path {p} contains a symlink loop; resolve the loop or remove "
-                "the offending symlink."
-            ),
-        ) from exc
-    if not resolved.is_relative_to(project_resolved):
-        raise ProfileNotFoundError(
-            searched_paths=[resolved],
-            remediation=(
-                f"Path {resolved} escapes project_dir {project_resolved}; "
-                "profiles.yml symlinks must point inside the project tree."
-            ),
-        )
-    return resolved

--- a/tests/_common/test_path_safety.py
+++ b/tests/_common/test_path_safety.py
@@ -108,6 +108,22 @@ def test_missing_project_dir_raises(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_project_dir_is_a_regular_file_raises(tmp_path: Path) -> None:
+    """A bare-file ``project_dir`` raises :class:`PathContainmentError`.
+
+    ``Path.resolve(strict=True)`` succeeds on an existing regular file
+    (it only raises on missing paths), so without an explicit
+    :meth:`Path.is_dir` guard the helper would silently accept a file
+    as ``project_dir``. Pinned per Copilot review on PR #72.
+    """
+    not_a_dir = tmp_path / "regular_file"
+    not_a_dir.write_text("x")
+
+    with pytest.raises(PathContainmentError, match="does not exist or is not a directory"):
+        canonicalise_path("any.txt", not_a_dir)
+
+
+@pytest.mark.unit
 def test_project_dir_with_file_in_path_raises(tmp_path: Path) -> None:
     """A ``project_dir`` whose path traverses a regular file raises
     :class:`PathContainmentError` (the ``NotADirectoryError`` branch

--- a/tests/_common/test_path_safety.py
+++ b/tests/_common/test_path_safety.py
@@ -1,0 +1,150 @@
+"""Unit tests for :mod:`signalforge._common.path_safety` (issue #43).
+
+The helper is consumed by every pipeline stage (cli/diff/grade/prune) plus
+the warehouse/safety layer wrappers. The cross-package consumers catch the
+layer-neutral :class:`PathContainmentError` directly; the warehouse/safety
+wrappers re-raise as their own typed error. This file pins the four
+failure modes at the source so a regression surfaces here even if every
+layer wrapper still translates correctly.
+
+The three traps from ``.claude/rules/manifest-readers.md`` are exercised:
+
+1. Resolve symlinks BEFORE checking containment.
+2. Catch :class:`RuntimeError` from :meth:`pathlib.Path.resolve` on cycles.
+3. Apply the gate to the *default* path the caller chooses, not just to
+   user-supplied overrides — exercised via the relative-path branch.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from signalforge._common.path_safety import PathContainmentError, canonicalise_path
+
+
+@pytest.mark.unit
+def test_relative_path_resolves_under_project(tmp_path: Path) -> None:
+    """A relative input resolves under the project_dir's canonical tree."""
+    project = tmp_path / "project"
+    project.mkdir()
+    target = project / "subdir" / "file.txt"
+    target.parent.mkdir()
+    target.write_text("x")
+
+    result = canonicalise_path("subdir/file.txt", project)
+
+    assert result == target.resolve()
+
+
+@pytest.mark.unit
+def test_absolute_path_inside_project_resolves(tmp_path: Path) -> None:
+    """An absolute input pointing inside project_dir is accepted."""
+    project = tmp_path / "project"
+    project.mkdir()
+    target = project / ".signalforge" / "audit.jsonl"
+
+    result = canonicalise_path(target, project)
+
+    assert result == target.resolve()
+
+
+@pytest.mark.unit
+def test_absolute_path_outside_project_raises(tmp_path: Path) -> None:
+    """An absolute path escaping project_dir raises :class:`PathContainmentError`."""
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside" / "etc.txt"
+    outside.parent.mkdir()
+
+    with pytest.raises(PathContainmentError, match="escapes project_dir"):
+        canonicalise_path(outside, project)
+
+
+@pytest.mark.unit
+def test_symlink_pointing_outside_project_raises(tmp_path: Path) -> None:
+    """A symlink resolved to an out-of-tree target raises :class:`PathContainmentError`."""
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside_file.txt"
+    outside.write_text("evil")
+
+    link = project / "linked.txt"
+    try:
+        os.symlink(outside, link)
+    except OSError:
+        pytest.skip("symlinks unsupported on this filesystem")
+
+    with pytest.raises(PathContainmentError, match="escapes project_dir"):
+        canonicalise_path("linked.txt", project)
+
+
+@pytest.mark.unit
+def test_input_symlink_loop_raises(tmp_path: Path) -> None:
+    """A symlink loop on the input path raises :class:`PathContainmentError`."""
+    project = tmp_path / "project"
+    project.mkdir()
+    loop_a = project / "a"
+    loop_b = project / "b"
+    try:
+        os.symlink(loop_b, loop_a)
+        os.symlink(loop_a, loop_b)
+    except OSError:
+        pytest.skip("symlinks unsupported on this filesystem")
+
+    with pytest.raises(PathContainmentError, match="symlink loop"):
+        canonicalise_path("a", project)
+
+
+@pytest.mark.unit
+def test_missing_project_dir_raises(tmp_path: Path) -> None:
+    """A non-existent ``project_dir`` raises :class:`PathContainmentError`."""
+    missing = tmp_path / "does-not-exist"
+
+    with pytest.raises(PathContainmentError, match="does not exist"):
+        canonicalise_path("any.txt", missing)
+
+
+@pytest.mark.unit
+def test_project_dir_with_file_in_path_raises(tmp_path: Path) -> None:
+    """A ``project_dir`` whose path traverses a regular file raises
+    :class:`PathContainmentError` (the ``NotADirectoryError`` branch
+    of :meth:`pathlib.Path.resolve`).
+    """
+    regular_file = tmp_path / "regular_file"
+    regular_file.write_text("x")
+    bogus_project = regular_file / "subdir"  # nested under a non-dir
+
+    with pytest.raises(PathContainmentError, match="does not exist or is not a directory"):
+        canonicalise_path("any.txt", bogus_project)
+
+
+@pytest.mark.unit
+def test_project_dir_symlink_loop_raises(tmp_path: Path) -> None:
+    """A symlink loop on ``project_dir`` itself raises :class:`PathContainmentError`."""
+    loop_a = tmp_path / "loop_a"
+    loop_b = tmp_path / "loop_b"
+    try:
+        os.symlink(loop_b, loop_a)
+        os.symlink(loop_a, loop_b)
+    except OSError:
+        pytest.skip("symlinks unsupported on this filesystem")
+
+    with pytest.raises(PathContainmentError, match="symlink loop"):
+        canonicalise_path("any.txt", loop_a)
+
+
+@pytest.mark.unit
+def test_path_containment_error_subclasses_exception() -> None:
+    """``PathContainmentError`` is a plain :class:`Exception` subclass.
+
+    Issue #43 — load-bearing invariant. The class deliberately does NOT
+    subclass a layer-specific error hierarchy (e.g. ``WarehouseError``).
+    """
+    assert issubclass(PathContainmentError, Exception)
+    # No layer hierarchy in the MRO above ``Exception``.
+    bases = [cls.__name__ for cls in PathContainmentError.__mro__]
+    assert "WarehouseError" not in bases
+    assert "SafetyError" not in bases

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -63,3 +63,37 @@ def test_unknown_command_no_traceback_in_stderr(
     main(["definitely-not-a-real-command"])
     captured = capsys.readouterr()
     assert "Traceback" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# canonicalise_user_path — symlink-hardened path-safety helper (issue #43)
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalise_user_path_returns_none_for_none_input(tmp_path):
+    """``None`` input passes through so callers can plumb optional flags
+    without a per-call ``if`` ladder.
+    """
+    from signalforge.cli._helpers import canonicalise_user_path
+
+    assert canonicalise_user_path(None, tmp_path) is None
+
+
+def test_canonicalise_user_path_rejects_path_outside_project(tmp_path):
+    """A path escaping ``project_dir`` raises :class:`CliPathError`
+    (the cross-package consumer's typed-error wrap of the layer-neutral
+    :class:`PathContainmentError` from
+    :mod:`signalforge._common.path_safety`).
+    """
+    from signalforge.cli._helpers import canonicalise_user_path
+    from signalforge.cli.errors import CliPathError
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x")
+
+    with pytest.raises(CliPathError) as excinfo:
+        canonicalise_user_path(str(outside), project_dir)
+
+    assert "failed safety check" in str(excinfo.value)

--- a/tests/grade/test_audit.py
+++ b/tests/grade/test_audit.py
@@ -46,9 +46,10 @@ from signalforge.grade.audit import (
     _GRADE_AUDIT_RECORD_LIMIT_BYTES,
     _build_grade_event,
     write_grade_event,
+    write_grading_report,
 )
 from signalforge.grade.errors import GradeAuditRecordTooLargeError, GradeAuditWriteError
-from signalforge.grade.models import GradeEvent
+from signalforge.grade.models import GradeEvent, GradingReport
 
 
 def _make_event(**overrides: Any) -> GradeEvent:
@@ -355,6 +356,44 @@ def test_write_grade_event_rejects_symlink_loop(tmp_path: Path) -> None:
 
     with pytest.raises(GradeAuditWriteError):
         write_grade_event(_make_event(), audit_path=audit_path)
+
+
+def _make_report(**overrides: Any) -> GradingReport:
+    base: dict[str, Any] = dict(
+        signalforge_version=signalforge.__version__,
+        run_id="0123456789abcdef0123456789abcdef",
+        timestamp=datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc),
+        duration_seconds=1.5,
+        model_unique_id="model.test.x",
+        rubric_hash="abc1234567890def",
+        thresholds=(0.5, 0.5),
+        results=(),
+    )
+    base.update(overrides)
+    return GradingReport(**base)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only symlink semantics")
+def test_write_grading_report_rejects_symlink_escape(tmp_path: Path) -> None:
+    """A symlink at ``<project>/.signalforge`` pointing outside the
+    project tree is rejected; the sidecar writer raises
+    :class:`GradeAuditWriteError` rather than write outside the project
+    sandbox. Pairs with :func:`test_write_grade_event_rejects_symlink_escape`
+    for the JSONL writer.
+    """
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    escape_dir = tmp_path / "escape"
+    escape_dir.mkdir()
+    sf_dir = project_dir / ".signalforge"
+    sf_dir.symlink_to(escape_dir, target_is_directory=True)
+    sidecar_path = project_dir / ".signalforge" / "grade.json"
+
+    with pytest.raises(GradeAuditWriteError) as excinfo:
+        write_grading_report(_make_report(), sidecar_path=sidecar_path)
+
+    assert excinfo.value.cause is not None
+    assert not (escape_dir / "grade.json").exists()
 
 
 def test_build_grade_event_attaches_signalforge_version() -> None:

--- a/tests/warehouse/test_path_safety_wrapper.py
+++ b/tests/warehouse/test_path_safety_wrapper.py
@@ -1,0 +1,75 @@
+"""Tests for the warehouse-layer ``_path_safety`` wrapper (issue #43).
+
+The wrapper translates the layer-neutral
+:class:`signalforge._common.path_safety.PathContainmentError` into
+:class:`signalforge.warehouse.errors.ProfileNotFoundError` so warehouse
+callers (``warehouse/profiles.py``) keep one typed-error catch surface.
+These tests pin the wrap's diagnostic shape — in particular
+``searched_paths`` carries the project-scoped location actually
+validated, not a cwd-relative bare name (Copilot regression catch on
+PR #72).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from signalforge.warehouse._path_safety import canonicalise_path
+from signalforge.warehouse.errors import ProfileNotFoundError
+
+
+@pytest.mark.unit
+def test_wrapper_translates_to_profile_not_found_error(tmp_path: Path) -> None:
+    """A containment failure inside the common helper surfaces as
+    :class:`ProfileNotFoundError` at the wrapper boundary.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.yml"
+    outside.write_text("x")
+
+    with pytest.raises(ProfileNotFoundError):
+        canonicalise_path(outside, project)
+
+
+@pytest.mark.unit
+def test_wrapper_searched_paths_is_project_scoped_for_relative_input(
+    tmp_path: Path,
+) -> None:
+    """A relative ``input_path`` records the project-scoped joined path
+    in ``ProfileNotFoundError.searched_paths``, not a cwd-relative bare
+    name. Pinned per Copilot review on PR #72 (the wrapper's
+    diagnostic surface for ``warehouse/profiles.py``-style callers).
+    """
+    # Trigger a failure on a relative input by pointing project_dir at a
+    # missing directory — the failure mode doesn't matter; we only check
+    # the searched_paths shape.
+    missing_project = tmp_path / "does-not-exist"
+
+    with pytest.raises(ProfileNotFoundError) as excinfo:
+        canonicalise_path("profiles.yml", missing_project)
+
+    searched = excinfo.value.searched_paths
+    assert len(searched) == 1
+    # Must include the project_dir context, not just the bare relative
+    # filename.
+    assert searched[0] == missing_project / "profiles.yml"
+
+
+@pytest.mark.unit
+def test_wrapper_searched_paths_preserves_absolute_input(tmp_path: Path) -> None:
+    """An absolute ``input_path`` is recorded verbatim in
+    ``searched_paths`` (no double-prefix with ``project_dir``).
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside" / "profiles.yml"
+
+    with pytest.raises(ProfileNotFoundError) as excinfo:
+        canonicalise_path(outside, project)
+
+    searched = excinfo.value.searched_paths
+    assert len(searched) == 1
+    assert searched[0] == outside


### PR DESCRIPTION
## Summary

Closes #43.

- Promote `canonicalise_path` to `signalforge._common.path_safety` with a project-neutral typed escape (`PathContainmentError(Exception)` — no layer prefix). Option A from the issue.
- Cross-package consumers (cli, diff/_sidecar, diff/config, diff/engine, grade/audit, grade/engine, prune/engine) now import from the common module directly and catch `PathContainmentError` at their orchestrator boundary, re-raising as their own layer-typed error.
- Layer wrappers `warehouse/_path_safety.py` and `safety/_path_safety.py` shrink to thin shims that delegate to the common helper and translate `PathContainmentError` → `ProfileNotFoundError` / `InvalidConfigError` for the layer's internal callers (`warehouse/profiles.py`, `safety/config.py`).
- Update `.claude/rules/warehouse-adapters.md` § "Path safety" — graduates from "duplicated, not extracted" to "layer-neutral common module + per-layer wrappers."

## Why this matters

A stack trace from a grade-layer audit write previously surfaced a warehouse-named `ProfileNotFoundError`. The escape exception is now `PathContainmentError`, owned by no layer, so each layer's catch surface stays homogeneous without leaking a warehouse name through grade/diff/prune/cli.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pyright` — 0 errors
- [x] `pytest` — 1647 passed (+9 new at `tests/_common/test_path_safety.py`), 13 deselected, 95.84% coverage
- [x] New tests cover all four failure modes (escape, input-path cycle, missing project_dir, project_dir-path-traverses-file) at the source — regressions surface here even if every wrapper still translates correctly.
- [x] `PathContainmentError` does NOT inherit from `WarehouseError` / `SafetyError` (pinned by `test_path_containment_error_subclasses_exception`).

## Acceptance criteria (from #43)

- [x] One canonical location for `canonicalise_path` — `signalforge._common.path_safety`.
- [x] Escape exception class name does not lead with `Profile` / `Warehouse` — it's `PathContainmentError`.
- [x] `.claude/rules/warehouse-adapters.md` § "Path safety" updated.
- [x] No regression in symlink/containment tests (1638 → 1647 passed; the three traps from `manifest-readers.md` still hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced symlink and path containment protection across all path validation operations, improving consistency and security when handling file paths.

* **Tests**
  * Added comprehensive test coverage for path canonicalisation and symlink containment validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->