### PR TITLE
45: switch logger grep gate to AST; cover manifest/ + multi-line bypass

### DIFF
--- a/.claude/rules/testing-signal.md
+++ b/.claude/rules/testing-signal.md
@@ -56,6 +56,28 @@ A bare-name-only visitor (`Call(func=Name(id=target))`) is trivially bypassable 
 
 Each new scan also needs a planted-violation regression test that exercises all three patterns. `tests/test_audit_completeness.py::test_qualified_name_finder_catches_all_three_bypass_patterns` is the precedent (one parametrised test across all gated targets × all three patterns).
 
+## Source-scan gates: AST over per-line regex (issue #45)
+
+Source-scanning gates that enforce a "no X in module Y" rule (the `_LOGGER` lazy-format gate at `tests/llm/test_logger_grep_gate.py`; the safety-layer literal-token gate; future similar tests) MUST be AST-based, never per-line regex. The historic logger gate used `re.search` per line and was trivially bypassable by splitting the call across lines:
+
+```python
+_LOGGER.info(
+    f"resolved project_dir: {project_dir}"  # NOT caught by per-line regex
+)
+```
+
+The general rule: any time a gate scans source code for a pattern that can legally span multiple lines in Python, reach for `ast.parse` + `ast.NodeVisitor` (or `ast.walk` for cheap one-off scans). The parser normalises every quote style, prefix permutation, and whitespace/newline arrangement into the same node type — `JoinedStr` for every f-string, `Import` / `ImportFrom` for every import variant, `Attribute(value=Name('logging'))` for every `logging.X` reference. A regex has to anticipate every textual permutation; the AST has one canonical form. `_LoggerFStringVisitor` and `_file_has_logging_or_logger_node` in `tests/llm/test_logger_grep_gate.py` are the precedent — copy the shape for any new "absence" gate.
+
+Three load-bearing details from the issue-#45 sharpening (PR #75 review):
+
+1. **Walk positional args AND keyword arg values, recursively.** A `_LOGGER.warning("stuff", extra={"x": f"bad {y}"})` call hides an f-string two layers deep inside a keyword arg. The visitor must `ast.walk(arg)` over every positional AND `kw.value` and check for the gated node anywhere in the subtree. Surface-level `isinstance` checks miss it.
+2. **Substring scans false-positive on docstrings / comments mentioning the gated token.** A rule citation like `"per manifest-readers.md, no _LOGGER allowed"` would trip a `if "_LOGGER" in source:` check. The AST walk over `Name(id='_LOGGER')` doesn't see string literals (those parse as `Constant`), so the false-positive vanishes. The companion test plants a docstring containing the gated token and asserts NO match.
+3. **For "no logging at all" stage-0 enforcement, the gate must cover every form of indirection.** `import logging`, `import logging as X`, `from logging import getLogger`, `logging.getLogger(__name__)`, and bare `_LOGGER` references are all separate AST node types — `Import`, `ImportFrom`, `Attribute(value=Name('logging'))`, `Name(id='_LOGGER')`. Cover each. A check that only matches the literal token `_LOGGER` lets `from logging import getLogger; LOG = getLogger(__name__)` slip through silently.
+
+Planted-violation self-checks are mandatory for the same reason as the audit-completeness scans (above): without them, a refactor that broke the visitor (e.g., dropped the `ast.walk` recursion or stopped checking keyword args) would silently disable the gate at the precise moment a real violation needed catching. The self-checks live in the same file as the gate and use the visitor directly against literal source strings, so they cost ~1ms and document the contract for any future maintainer in line with the production walker.
+
+When v0.x adds a new source-scanning gate (e.g., "no `print(...)` in production modules", "no `open(...)` outside the fail-closed writer modules", "no `time.sleep` outside `_sleep` aliases"), follow this shape: AST visitor, walk positional + keyword args recursively, planted-violation self-checks, false-positive control case. The cheap floor of `grep -r` belongs in interactive maintainer workflows, not in the test suite.
+
 ## Coverage measurement
 
 Established by issue #27 (DEC-001, DEC-004, DEC-009). Coverage instrumentation runs both locally and in CI via `--cov*` flags in `pyproject.toml` `addopts`.

--- a/tests/llm/test_logger_grep_gate.py
+++ b/tests/llm/test_logger_grep_gate.py
@@ -50,6 +50,7 @@ _SCAN_SUBPACKAGES: tuple[str, ...] = (
     "llm",
     "manifest",
     "prune",
+    "safety",
     "warehouse",
 )
 
@@ -75,11 +76,11 @@ class _LoggerFStringVisitor(ast.NodeVisitor):
     """
 
     def __init__(self) -> None:
-        self.violations: list[tuple[int, int]] = []  # (lineno, col_offset)
+        self.violations: list[int] = []  # 1-based linenos
 
     def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 — ast convention
         if _is_logger_attribute_call(node.func) and _any_arg_contains_fstring(node):
-            self.violations.append((node.lineno, node.col_offset))
+            self.violations.append(node.lineno)
         self.generic_visit(node)
 
 
@@ -105,20 +106,21 @@ def _any_arg_contains_fstring(call: ast.Call) -> bool:
     return False
 
 
-def _scan_file(path: Path) -> list[tuple[Path, int, int]]:
-    """Return ``(path, lineno, col_offset)`` for every f-string
-    ``_LOGGER`` call in ``path``.
+def _scan_file(path: Path) -> list[tuple[Path, int]]:
+    """Return ``(path, lineno)`` for every f-string ``_LOGGER`` call
+    in ``path``. Linenos are 1-based, consistent with other AST-scan
+    tests in this repo (e.g. ``tests/safety/test_public_api.py``).
     """
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     visitor = _LoggerFStringVisitor()
     visitor.visit(tree)
-    return [(path, lineno, col) for lineno, col in visitor.violations]
+    return [(path, lineno) for lineno in visitor.violations]
 
 
-def _scan_subpackage(name: str) -> list[tuple[Path, int, int]]:
+def _scan_subpackage(name: str) -> list[tuple[Path, int]]:
     """Walk ``src/signalforge/<name>/**/*.py`` and collect violations."""
     root = _SRC_ROOT / name
-    hits: list[tuple[Path, int, int]] = []
+    hits: list[tuple[Path, int]] = []
     for path in sorted(root.rglob("*.py")):
         hits.extend(_scan_file(path))
     return hits
@@ -137,11 +139,11 @@ def test_no_f_string_logger_calls_across_subpackages() -> None:
     inject directly into log viewers when interpolated via f-string;
     JSON encoding escapes them safely.
     """
-    hits: list[tuple[Path, int, int]] = []
+    hits: list[tuple[Path, int]] = []
     for subpkg in _SCAN_SUBPACKAGES:
         hits.extend(_scan_subpackage(subpkg))
 
-    formatted = "\n".join(f"  {p}:{lineno}:{col}" for p, lineno, col in hits)
+    formatted = "\n".join(f"  {p}:{lineno}" for p, lineno in hits)
     covered = " / ".join(f"signalforge.{name}" for name in _SCAN_SUBPACKAGES)
     assert not hits, (
         f"Found f-string-interpolated _LOGGER calls in {covered} "
@@ -152,28 +154,66 @@ def test_no_f_string_logger_calls_across_subpackages() -> None:
     )
 
 
+def _file_has_logging_or_logger_node(path: Path) -> str | None:
+    """Return a short reason string if ``path``'s AST contains:
+
+    - ``import logging`` or ``import logging as X``
+    - ``from logging import ...``
+    - any ``logging.<attr>`` reference (e.g. ``logging.getLogger``)
+    - any ``Name(id='_LOGGER')`` reference (assignment or use)
+
+    Otherwise return ``None``. An AST walk avoids substring
+    false-positives (e.g. the literal token ``_LOGGER`` inside a
+    docstring or comment) and catches indirection like ``from logging
+    import getLogger; LOG = getLogger(__name__)`` that a raw token
+    scan would miss.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import) and any(
+            alias.name == "logging" or alias.name.startswith("logging.") for alias in node.names
+        ):
+            return "imports the logging module"
+        if isinstance(node, ast.ImportFrom) and node.module == "logging":
+            return "imports from the logging module"
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "logging"
+        ):
+            return f"references logging.{node.attr}"
+        if isinstance(node, ast.Name) and node.id == "_LOGGER":
+            return "references a _LOGGER name"
+    return None
+
+
 def test_manifest_subpackage_has_no_logger_at_all() -> None:
-    """Issue #45: ``signalforge.manifest`` is a stage-0 reader/parser
-    per ``manifest-readers.md`` § "No logging / metrics in stage-0
-    modules"; it must not import :mod:`logging` or define
+    """Issue #45 (sharpened from PR #75 review): ``signalforge.manifest``
+    is a stage-0 reader/parser per ``manifest-readers.md`` § "No
+    logging / metrics in stage-0 modules"; it must not import
+    :mod:`logging`, reference :mod:`logging` attributes, or define
     ``_LOGGER``.
 
     The f-string gate above also covers ``manifest/``, but a future
-    addition that introduced ``_LOGGER`` with lazy-format JSON would
-    pass that gate while still violating the stage-0 rule. This
-    second assertion enforces absence directly.
+    addition that introduced lazy-format ``_LOGGER`` calls would pass
+    that gate while still violating the stage-0 rule. This second
+    assertion enforces absence directly via an AST walk so the check
+    catches every form of logging indirection (``import logging``,
+    ``from logging import getLogger``, ``logging.getLogger(...)``,
+    bare ``_LOGGER`` references) without false-positives on docstring
+    mentions of the token.
     """
     manifest_root = _SRC_ROOT / "manifest"
-    offenders: list[Path] = []
+    offenders: list[tuple[Path, str]] = []
     for path in sorted(manifest_root.rglob("*.py")):
-        source = path.read_text(encoding="utf-8")
-        if "_LOGGER" in source:
-            offenders.append(path)
-    formatted = "\n".join(f"  {p}" for p in offenders)
+        reason = _file_has_logging_or_logger_node(path)
+        if reason is not None:
+            offenders.append((path, reason))
+    formatted = "\n".join(f"  {p} — {reason}" for p, reason in offenders)
     assert not offenders, (
-        "signalforge.manifest is a stage-0 reader and must not declare "
-        "a _LOGGER (manifest-readers.md § 'No logging / metrics in "
-        f"stage-0 modules'):\n{formatted}"
+        "signalforge.manifest is a stage-0 reader and must not import "
+        "logging or define _LOGGER (manifest-readers.md § 'No logging "
+        f"/ metrics in stage-0 modules'):\n{formatted}"
     )
 
 
@@ -219,11 +259,20 @@ _GOOD_CASES: tuple[str, ...] = (
 )
 
 
-def _visit_source(source: str) -> list[tuple[int, int]]:
+def _visit_source(source: str) -> list[int]:
     tree = ast.parse(source)
     visitor = _LoggerFStringVisitor()
     visitor.visit(tree)
     return visitor.violations
+
+
+def _check_manifest_detector(source: str, tmp_path: Path, name: str) -> str | None:
+    """Write ``source`` to a temp ``.py`` file and run the stage-0
+    AST detector against it. Returns the reason string, or ``None``.
+    """
+    path = tmp_path / f"{name}.py"
+    path.write_text(source, encoding="utf-8")
+    return _file_has_logging_or_logger_node(path)
 
 
 def test_visitor_catches_single_line_fstring_calls() -> None:
@@ -266,3 +315,43 @@ def test_visitor_does_not_match_safe_calls() -> None:
     for source in _GOOD_CASES:
         violations = _visit_source(source)
         assert not violations, f"visitor false-matched: {source!r}"
+
+
+def test_manifest_detector_catches_every_logging_indirection(tmp_path: Path) -> None:
+    """PR #75 review: the manifest stage-0 check must catch every
+    form of logging indirection, not just the literal token
+    ``_LOGGER``. ``import logging``, ``from logging import getLogger``,
+    a ``logging.<attr>`` reference, and a bare ``_LOGGER`` name all
+    have to trip the detector.
+    """
+    cases = (
+        ("import_logging", "import logging\n"),
+        ("import_logging_as", "import logging as _log\n"),
+        ("from_logging_import", "from logging import getLogger\n_LOG = getLogger(__name__)\n"),
+        ("logging_getLogger", "import logging\n_LOG = logging.getLogger(__name__)\n"),
+        ("bare_logger_assignment", "_LOGGER = object()\n"),
+        ("bare_logger_call", "_LOGGER.info('x')\n"),
+    )
+    for name, source in cases:
+        reason = _check_manifest_detector(source, tmp_path, name)
+        assert reason is not None, f"detector missed {name!r}: {source!r}"
+
+
+def test_manifest_detector_does_not_false_positive_on_token_in_docstring(
+    tmp_path: Path,
+) -> None:
+    """PR #75 review: a docstring or comment mentioning the literal
+    string ``_LOGGER`` (e.g. a rule citation) must NOT trip the
+    detector. The historic substring check would have false-matched
+    here; the AST walk fixes that.
+    """
+    docstring_only = (
+        '"""Stage-0 reader; per manifest-readers.md must not define _LOGGER."""\n'
+        "# `_LOGGER` is forbidden here — see the rule file.\n"
+        "x = 1\n"
+    )
+    reason = _check_manifest_detector(docstring_only, tmp_path, "docstring_mention")
+    assert reason is None, (
+        "detector false-positive on a docstring / comment that mentions "
+        f"the literal token _LOGGER: {reason!r}"
+    )

--- a/tests/llm/test_logger_grep_gate.py
+++ b/tests/llm/test_logger_grep_gate.py
@@ -1,87 +1,150 @@
-"""ANSI-safe lazy-format logger grep gate (US-014 / DEC-011).
+"""ANSI-safe lazy-format logger gate (US-014 / DEC-011) — AST-based.
 
-Mirrors the safety layer's DEC-022 grep gate, extended to
+Mirrors the safety layer's DEC-022 gate, extended to
 :mod:`signalforge.llm`, :mod:`signalforge.draft`,
 :mod:`signalforge.prune`, :mod:`signalforge.grade`,
-:mod:`signalforge.diff` (DEC-019 of #8), and :mod:`signalforge.cli`
-(DEC-017 of #9). Every
-``_LOGGER.{info,warning,debug,error}`` call in those subpackages must
-use lazy ``%s``-formatting with :func:`json.dumps` for any
-user-controlled string — never f-string interpolation. A column name
-or model id containing ANSI escapes (``\\x1b[31m...``) would inject into
-log viewers when interpolated via f-string; JSON encoding handles this,
-f-string does not.
+:mod:`signalforge.diff` (DEC-019 of #8), :mod:`signalforge.cli`
+(DEC-017 of #9), :mod:`signalforge.warehouse` (QG fix of #22), and
+:mod:`signalforge.manifest` (issue #45 — gate doubles as a stage-0
+"no logging" enforcer; per ``manifest-readers.md`` § "No logging /
+metrics in stage-0 modules" the package should have no ``_LOGGER`` at
+all, so any f-string ``_LOGGER`` call there is doubly wrong).
 
-This test is the cheap floor: a regex over the source. The runtime
-equivalent in the safety layer is :mod:`tests.safety.test_audit`'s
-control-character round-trip.
+Every ``_LOGGER.{info,warning,debug,error,...}`` call in those
+subpackages must use lazy ``%s``-formatting with :func:`json.dumps`
+for any user-controlled string — never f-string interpolation. A
+column name or model id containing ANSI escapes (``\\x1b[31m...``)
+would inject into log viewers when interpolated via f-string; JSON
+encoding handles this, f-string does not.
+
+The historic implementation was a per-line :mod:`re` scan, which a
+contributor could trivially bypass by splitting the call across
+lines (issue #45)::
+
+    _LOGGER.info(
+        f"resolved project_dir: {project_dir}"  # NOT caught by per-line regex
+    )
+
+This module uses :mod:`ast` instead: it walks every
+``Call(func=Attribute(value=Name('_LOGGER')))`` node and checks
+whether any argument is an :class:`ast.JoinedStr` (f-string),
+catching every quote style, prefix permutation, and whitespace /
+newline arrangement uniformly.
 """
 
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-_LLM_DIR = _REPO_ROOT / "src" / "signalforge" / "llm"
-_DRAFT_DIR = _REPO_ROOT / "src" / "signalforge" / "draft"
-_PRUNE_DIR = _REPO_ROOT / "src" / "signalforge" / "prune"
-_GRADE_DIR = _REPO_ROOT / "src" / "signalforge" / "grade"
-_DIFF_DIR = _REPO_ROOT / "src" / "signalforge" / "diff"
-_CLI_DIR = _REPO_ROOT / "src" / "signalforge" / "cli"
-_WAREHOUSE_DIR = _REPO_ROOT / "src" / "signalforge" / "warehouse"
+_SRC_ROOT = _REPO_ROOT / "src" / "signalforge"
 
-# Matches ``_LOGGER.<method>(f"...``, ``_LOGGER.<method>(f'...``,
-# ``_LOGGER.<method>( f"...``, ``_LOGGER.<method>(rf"...``,
-# ``_LOGGER.<method>(fr'...``, etc. on a single line.
-#
-# Catches every Python f-string form: any prefix permutation of `f` and
-# `r` (case-insensitive), single OR double OR triple quotes, optional
-# whitespace after the opening paren. Without this breadth a contributor
-# could trivially bypass the DEC-011 gate by switching quote style.
-_F_STRING_LOGGER_RE = re.compile(r"""_LOGGER\.\w+\(\s*(?:[fF][rR]?|[rR][fF])['"]""")
+# Subpackages covered by the gate. Order is alphabetical for ease of
+# diffing when a future stage extends the list.
+_SCAN_SUBPACKAGES: tuple[str, ...] = (
+    "cli",
+    "diff",
+    "draft",
+    "grade",
+    "llm",
+    "manifest",
+    "prune",
+    "warehouse",
+)
 
 
-def _scan_for_f_string_logger_calls(root: Path) -> list[tuple[Path, int, str]]:
-    """Walk ``root.rglob('*.py')``; return ``(path, lineno, line)`` for
-    every match of :data:`_F_STRING_LOGGER_RE`.
+class _LoggerFStringVisitor(ast.NodeVisitor):
+    """Collects ``Call`` nodes that interpolate an f-string into a
+    ``_LOGGER.<method>(...)`` call.
+
+    Match conditions:
+
+    - ``func`` is ``Attribute(value=Name(id='_LOGGER'), attr=<any>)`` —
+      any logger method (``info``, ``warning``, ``debug``, ``error``,
+      ``exception``, ``critical``, ``log``).
+    - Any positional arg OR keyword-arg value contains (recursively) an
+      :class:`ast.JoinedStr`. Recursion catches f-strings nested inside
+      tuples / lists / function calls that happen to be passed as args
+      (rare, but the gate stays robust).
+
+    A bare :class:`ast.JoinedStr` arg covers every f-string prefix
+    permutation (``f"..."``, ``rf"..."``, ``fr"..."``, ``F"..."``,
+    ``Rf"..."``, ...) — the parser normalises all of them into the
+    same AST node.
     """
-    hits: list[tuple[Path, int, str]] = []
-    for path in root.rglob("*.py"):
-        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            if _F_STRING_LOGGER_RE.search(line):
-                hits.append((path, lineno, line.rstrip()))
+
+    def __init__(self) -> None:
+        self.violations: list[tuple[int, int]] = []  # (lineno, col_offset)
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 — ast convention
+        if _is_logger_attribute_call(node.func) and _any_arg_contains_fstring(node):
+            self.violations.append((node.lineno, node.col_offset))
+        self.generic_visit(node)
+
+
+def _is_logger_attribute_call(func: ast.expr) -> bool:
+    """``True`` iff ``func`` is ``_LOGGER.<method>``."""
+    return (
+        isinstance(func, ast.Attribute)
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "_LOGGER"
+    )
+
+
+def _any_arg_contains_fstring(call: ast.Call) -> bool:
+    """``True`` iff any positional or keyword arg of ``call`` contains
+    an :class:`ast.JoinedStr` at any nesting depth.
+    """
+    candidates: list[ast.AST] = list(call.args)
+    candidates.extend(kw.value for kw in call.keywords)
+    for arg in candidates:
+        for sub in ast.walk(arg):
+            if isinstance(sub, ast.JoinedStr):
+                return True
+    return False
+
+
+def _scan_file(path: Path) -> list[tuple[Path, int, int]]:
+    """Return ``(path, lineno, col_offset)`` for every f-string
+    ``_LOGGER`` call in ``path``.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    visitor = _LoggerFStringVisitor()
+    visitor.visit(tree)
+    return [(path, lineno, col) for lineno, col in visitor.violations]
+
+
+def _scan_subpackage(name: str) -> list[tuple[Path, int, int]]:
+    """Walk ``src/signalforge/<name>/**/*.py`` and collect violations."""
+    root = _SRC_ROOT / name
+    hits: list[tuple[Path, int, int]] = []
+    for path in sorted(root.rglob("*.py")):
+        hits.extend(_scan_file(path))
     return hits
 
 
-def test_no_f_string_logger_calls_in_llm_draft_prune_grade_diff_or_cli_modules() -> None:
-    """DEC-011 / DEC-019 of #8 / DEC-017 of #9 / QG fix of #22: no
-    f-string-interpolated ``_LOGGER`` calls in :mod:`signalforge.llm`,
-    :mod:`signalforge.draft`, :mod:`signalforge.prune`,
-    :mod:`signalforge.grade`, :mod:`signalforge.diff`,
-    :mod:`signalforge.cli`, or :mod:`signalforge.warehouse` (added by
-    issue #22's QG review — US-003 introduced the cleanup-failure
-    WARNING and INFO logs in the warehouse layer).
+def test_no_f_string_logger_calls_across_subpackages() -> None:
+    """DEC-011 / DEC-019 of #8 / DEC-017 of #9 / QG fix of #22 / issue
+    #45: no f-string-interpolated ``_LOGGER`` calls in any covered
+    subpackage.
+
+    AST-based: catches single-line, multi-line, every quote / prefix
+    permutation, and any future arg-positioning the language allows.
 
     Use lazy ``%s`` formatting with :func:`json.dumps` for any
     user-controlled string. ANSI escapes in column names / model ids
     inject directly into log viewers when interpolated via f-string;
     JSON encoding escapes them safely.
     """
-    hits = (
-        _scan_for_f_string_logger_calls(_LLM_DIR)
-        + _scan_for_f_string_logger_calls(_DRAFT_DIR)
-        + _scan_for_f_string_logger_calls(_PRUNE_DIR)
-        + _scan_for_f_string_logger_calls(_GRADE_DIR)
-        + _scan_for_f_string_logger_calls(_DIFF_DIR)
-        + _scan_for_f_string_logger_calls(_CLI_DIR)
-        + _scan_for_f_string_logger_calls(_WAREHOUSE_DIR)
-    )
-    formatted = "\n".join(f"  {p}:{line}: {content}" for p, line, content in hits)
+    hits: list[tuple[Path, int, int]] = []
+    for subpkg in _SCAN_SUBPACKAGES:
+        hits.extend(_scan_subpackage(subpkg))
+
+    formatted = "\n".join(f"  {p}:{lineno}:{col}" for p, lineno, col in hits)
+    covered = " / ".join(f"signalforge.{name}" for name in _SCAN_SUBPACKAGES)
     assert not hits, (
-        "Found f-string-interpolated _LOGGER calls in signalforge.llm / "
-        "signalforge.draft / signalforge.prune / signalforge.grade / "
-        "signalforge.diff / signalforge.cli / signalforge.warehouse "
+        f"Found f-string-interpolated _LOGGER calls in {covered} "
         "(DEC-011 violation):\n"
         f"{formatted}\n"
         "Use lazy-format with json.dumps instead, e.g.:\n"
@@ -89,28 +152,117 @@ def test_no_f_string_logger_calls_in_llm_draft_prune_grade_diff_or_cli_modules()
     )
 
 
-def test_grep_gate_regex_matches_planted_violation() -> None:
-    """Self-check: the regex catches every f-string form. Without
-    this we'd not notice if a refactor broke the regex silently.
-    """
-    bad_cases = (
-        '_LOGGER.info(f"x={x}")',
-        "_LOGGER.info(f'x={x}')",
-        '_LOGGER.info( f"x={x}")',  # whitespace after paren
-        '_LOGGER.info(rf"x={x}")',
-        "_LOGGER.info(rf'x={x}')",
-        '_LOGGER.info(fr"x={x}")',
-        '_LOGGER.warning(F"x={x}")',  # uppercase F
-    )
-    for bad in bad_cases:
-        assert _F_STRING_LOGGER_RE.search(bad), f"regex missed: {bad!r}"
+def test_manifest_subpackage_has_no_logger_at_all() -> None:
+    """Issue #45: ``signalforge.manifest`` is a stage-0 reader/parser
+    per ``manifest-readers.md`` § "No logging / metrics in stage-0
+    modules"; it must not import :mod:`logging` or define
+    ``_LOGGER``.
 
-    good_cases = (
-        '_LOGGER.info("x: %s", json.dumps({"x": x}))',
-        '_LOGGER.info("plain string with no interpolation")',
-        # Don't match a random `_LOGGER.x(...)` followed by an f-string
-        # NOT inside the call (this is implementation-dependent — the
-        # regex is line-scoped so the first match wins).
+    The f-string gate above also covers ``manifest/``, but a future
+    addition that introduced ``_LOGGER`` with lazy-format JSON would
+    pass that gate while still violating the stage-0 rule. This
+    second assertion enforces absence directly.
+    """
+    manifest_root = _SRC_ROOT / "manifest"
+    offenders: list[Path] = []
+    for path in sorted(manifest_root.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "_LOGGER" in source:
+            offenders.append(path)
+    formatted = "\n".join(f"  {p}" for p in offenders)
+    assert not offenders, (
+        "signalforge.manifest is a stage-0 reader and must not declare "
+        "a _LOGGER (manifest-readers.md § 'No logging / metrics in "
+        f"stage-0 modules'):\n{formatted}"
     )
-    for good in good_cases:
-        assert not _F_STRING_LOGGER_RE.search(good), f"regex spurious-matched: {good!r}"
+
+
+# Self-checks for the visitor. Without these, a refactor that broke
+# the visitor (e.g., dropped the ``ast.walk`` recursion or stopped
+# checking keyword args) would silently disable the gate.
+
+_SINGLE_LINE_VIOLATIONS: tuple[str, ...] = (
+    '_LOGGER.info(f"x={x}")',
+    "_LOGGER.info(f'x={x}')",
+    '_LOGGER.info( f"x={x}")',  # whitespace after paren
+    '_LOGGER.info(rf"x={x}")',
+    "_LOGGER.info(rf'x={x}')",
+    '_LOGGER.info(fr"x={x}")',
+    '_LOGGER.warning(F"x={x}")',  # uppercase F
+    '_LOGGER.debug(f"""multi\nline\nbody {x}""")',  # triple-quoted f-string
+    '_LOGGER.exception(f"err {x}")',  # any logger method, not just info
+    '_LOGGER.log(logging.INFO, f"msg {x}")',  # second positional arg
+)
+
+_MULTILINE_VIOLATION = """\
+_LOGGER.info(
+    f"resolved project_dir: {project_dir}"
+)
+"""
+
+_MULTILINE_KWARG_VIOLATION = """\
+_LOGGER.warning(
+    "stuff",
+    extra={"x": f"bad {y}"},
+)
+"""
+
+_GOOD_CASES: tuple[str, ...] = (
+    '_LOGGER.info("x: %s", json.dumps({"x": x}))',
+    '_LOGGER.info("plain string with no interpolation")',
+    '_LOGGER.warning("audit: %s", json.dumps(payload))',
+    # An f-string OUTSIDE a _LOGGER call must NOT match.
+    'msg = f"context {x}"\n_LOGGER.info("msg: %s", msg)',
+    # `.format()` is still discouraged (not lazy), but it is NOT an
+    # f-string — the gate intentionally targets f-strings only.
+    '_LOGGER.info("x: {}".format(x))',
+)
+
+
+def _visit_source(source: str) -> list[tuple[int, int]]:
+    tree = ast.parse(source)
+    visitor = _LoggerFStringVisitor()
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def test_visitor_catches_single_line_fstring_calls() -> None:
+    """Sanity: every single-line f-string ``_LOGGER`` form is caught."""
+    for source in _SINGLE_LINE_VIOLATIONS:
+        violations = _visit_source(source)
+        assert violations, f"visitor missed: {source!r}"
+
+
+def test_visitor_catches_multiline_fstring_call() -> None:
+    """Issue #45: the multi-line bypass — ``_LOGGER.info(`` and the
+    ``f"..."`` on different lines — must be caught.
+
+    This is the regression test for the historic per-line regex
+    bypass. Run against the prior implementation, this test would
+    fail loud.
+    """
+    violations = _visit_source(_MULTILINE_VIOLATION)
+    assert violations, (
+        "visitor missed the multi-line f-string _LOGGER call "
+        "(the bypass the per-line regex couldn't catch)"
+    )
+
+
+def test_visitor_catches_fstring_in_keyword_arg() -> None:
+    """Defence-in-depth: an f-string passed via a keyword arg (e.g.
+    ``extra={"x": f"..."}``) must also be caught. The historic regex
+    accidentally covered this for single-line calls; the AST walk
+    must keep covering it.
+    """
+    violations = _visit_source(_MULTILINE_KWARG_VIOLATION)
+    assert violations, "visitor missed an f-string nested inside a keyword arg"
+
+
+def test_visitor_does_not_match_safe_calls() -> None:
+    """Sanity: lazy-format and non-``_LOGGER`` f-strings must not
+    match. Without this we'd silently turn the gate into a noisy
+    false-positive generator.
+    """
+    for source in _GOOD_CASES:
+        violations = _visit_source(source)
+        assert not violations, f"visitor false-matched: {source!r}"


### PR DESCRIPTION
## Summary

- Replace the per-line `re.search` gate in `tests/llm/test_logger_grep_gate.py` with an `ast.NodeVisitor` that walks every `Call(func=Attribute(value=Name('_LOGGER')))` and flags any arg containing an `ast.JoinedStr` — recursive over positional + keyword args, so multi-line splits, every f-string prefix permutation, and nested `extra={...}` dicts are all caught uniformly.
- Add `signalforge.manifest/` to the scan set with a paired stage-0 "no `_LOGGER` at all" assertion per `manifest-readers.md` § "No logging / metrics in stage-0 modules" — zero findings today; the gate is the future regression net.
- Plant single-line, multi-line, and keyword-arg violations against the visitor directly so a refactor that broke the AST walk fails loud instead of silently disabling the gate.

Closes #45.

## Test plan

- [x] `pytest tests/llm/test_logger_grep_gate.py -v` — 6 passed (production scan + manifest stage-0 + 4 self-checks).
- [x] `ruff check . && ruff format --check . && pyright` — clean.
- [x] Full `pytest` — 1,652 passed; 6 symlink-loop failures are pre-existing on `dev` (verified by stashing this change and re-running), unrelated to this PR.
- [x] Verified the historic regex misses the multi-line case: `re.compile(r"_LOGGER\\.\\w+\\(\\s*(?:[fF][rR]?|[rR][fF])['\"]").search(line)` returns no match across the lines of a split `_LOGGER.info(\\n    f"...")` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced logger validation testing with improved detection mechanisms for f-string usage in logging calls across multiple subpackages, including support for multi-line cases and keyword arguments.
  * Added comprehensive test coverage for both violation detection and safe logging patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->