### PR TITLE
48: surface `signalforge lint` in README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Full reference: [docs/safety-ops.md](docs/safety-ops.md),
 [docs/prune-ops.md](docs/prune-ops.md),
 [docs/grade-ops.md](docs/grade-ops.md).
 
-### 4. First run
+### 4. Prepare the fixture
 
 Copy the fixture to a writable tmp dir and rewrite the profile to bill
 queries against your project (the committed `profiles.yml` is oriented
@@ -124,7 +124,32 @@ austin:
       location: US
       maximum_bytes_billed: 1000000000
 EOF
+```
 
+### 5. Validate config (`signalforge lint`)
+
+Before paying for an LLM call, run the config-only validator. It loads
+`signalforge.yml`, the dbt manifest, and the warehouse profile through
+every per-stage loader — no warehouse calls, no Anthropic calls, no
+network — and reports every block that fails to parse in one shot.
+Sub-second; catches typos like `safety: { mdoel: ... }` that the
+`extra="forbid"` config models would otherwise surface only after a
+billable `generate` run:
+
+```bash
+signalforge lint --project-dir /tmp/sf-austin
+```
+
+On success, stdout is silent (git-style) and the exit code is `0`.
+Failures are listed on stderr with the offending block(s) named —
+single-failure runs use the `ERROR: <message>` shape; multi-failure
+runs emit a header + one bullet per block. See
+[`docs/cli-ops.md`](docs/cli-ops.md) § `signalforge lint` for the full
+contract.
+
+### 6. First run
+
+```bash
 signalforge generate models/staging/stg_bikeshare_trips.sql --project-dir /tmp/sf-austin
 ```
 
@@ -135,7 +160,7 @@ plus a single BigQuery `dryRun`). See
 [`docs/cli-ops.md`](docs/cli-ops.md) § `--estimate` for the full
 contract.
 
-### 5. Expected output
+### 7. Expected output
 
 The diff lists drafted column descriptions and signal-bearing tests
 alongside dropped tests with a one-line "why". The kept/dropped/flagged

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -262,6 +262,12 @@ Multi-error reporting (DEC-008): when more than one block fails,
 than short-circuiting on the first. Stdout is silent on success
 (git-style); stderr carries the failures.
 
+The Quick Start in [`README.md`](../README.md#5-validate-config-signalforge-lint)
+runs `signalforge lint` immediately after the fixture is prepared and
+before the first `signalforge generate` call — sub-second, free, and
+catches `extra="forbid"` typos (e.g. `safety: { mdoel: ... }`) that
+would otherwise surface only after a billable LLM round-trip.
+
 ### `signalforge version`
 
 Print the same string as `signalforge --version` and exit 0. Both


### PR DESCRIPTION
## Summary

- Inserts `signalforge lint` as step 5 of the README Quick Start, after fixture prep and before the first `signalforge generate` call — sub-second, free, catches `extra="forbid"` config typos (e.g. `safety: { mdoel: ... }`) that today only surface after a billable LLM round-trip.
- Splits the prior step 4 ("First run") into 4 (Prepare the fixture) + 6 (First run) so the prepare → validate → generate ordering reads linearly. Step 5 (Expected output) renumbers to 7.
- Adds a back-reference from `docs/cli-ops.md` § `signalforge lint` to the new Quick Start anchor so the contract surface and the onboarding surface point at each other.

## Test plan

- [ ] Render the README on GitHub and confirm step ordering (1–7) and the anchor link in `docs/cli-ops.md` resolve.
- [ ] Confirm `signalforge lint --project-dir /tmp/sf-austin` exits 0 with silent stdout against a clean fixture (matches the documented contract).

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)