### PR TITLE
49: extend `signalforge lint` to load the dbt manifest

### DIFF
--- a/.claude/rules/cli-layer.md
+++ b/.claude/rules/cli-layer.md
@@ -225,8 +225,31 @@ Plus optional failure block when ≥1 model failed. Summary emits when `(matched
 
 When v0.3 introduces parallel batch execution (deferred from #37), the per-model boundary catch needs to coordinate with whatever concurrency primitive lands. The current sequential pattern lays the groundwork: outcome-as-typed-result + max-aggregation generalises cleanly.
 
+## Bare-name model resolution lives in the CLI subcommand, not the manifest layer (issue #49)
+
+`Manifest.get_model(key)` accepts the unique_id form (`model.<pkg>.<name>`) and the file-path form (`models/path/to/<name>.sql`); a bare name like `customers` routes through the file-path branch and surfaces a confusing `ModelNotFoundError` even when a model with that name exists. This is the gotcha pinned by `testing-signal.md` § "Multi-surface drift on user-facing model arguments".
+
+Issue #49 shipped `signalforge lint --model <name>` with a private resolver `_resolve_model_for_lint` in `signalforge.cli.lint` that augments the manifest layer's resolver with a third branch:
+
+```python
+if key.startswith("model.") or "/" in key or key.endswith(".sql"):
+    return manifest.get_model(key)               # unique_id or file path
+matches = [m for m in manifest.iter_models() if m.name == key]
+if len(matches) == 1: return matches[0]          # bare name, unambiguous
+if len(matches) > 1: raise ModelNotFoundError(... "matches N enabled models" ...)
+raise ModelNotFoundError(... "No enabled model with name <key>" ...)
+```
+
+Three load-bearing conventions:
+
+1. **The bare-name branch lives in the CLI subcommand, NOT the manifest layer.** `Manifest.get_model` stays a strict two-form resolver because library callers (the prune engine, the drafter, future programmatic consumers) work in unique_ids and don't want bare-name disambiguation cost on every call. The CLI is the only surface where operators type by hand, and that's where the convenience belongs. Mirrors the precedent from `cli-layer.md` § "Stderr message shape" — escape and convenience at the sink, not in the layer.
+2. **Multiple matches fail loud with a disambiguation list, not first-wins.** A cross-package collision (two dbt packages each defining a `customers` model) should never silently pick one — the operator's intent is ambiguous. The list is capped at 5 unique_ids + `(+K more)` to keep stderr readable; the remediation tells them to switch to the unique_id or file-path form.
+3. **Disabled models do NOT match bare-name lookup.** `iter_models()` yields only enabled `resource_type == "model"` nodes; disabled-package models surface only via the unique_id form (which routes through `get_model` and raises `ModelDisabledError` separately). This keeps the bare-name UX honest — the operator sees only models they could actually run against — while preserving the ability to ask explicitly about a disabled model via its unique_id.
+
+When `cmd_generate` (or any future subcommand that takes a model arg) wants the same affordance, hoist `_resolve_model_for_lint` to `signalforge.cli._helpers` rather than copy-pasting. The two consumers' contracts are identical; the only thing v0.1 ships separately is the lint surface because issue #49's scope was bounded.
+
 ## Reference
 
-`plans/super/9-cli-entrypoint.md` — DEC-001 … DEC-027. `plans/super/37-multi-model-select.md` — DEC-001 … DEC-017 (multi-model batch additions). `src/signalforge/cli/` — current implementation. `docs/cli-ops.md` — operational reference. `tests/cli/` — in-process and subprocess test suite. `tests/test_audit_completeness.py::test_every_typed_error_is_in_exit_code_mapping_table` — 7th AST scan (DEC-024). `tests/llm/test_logger_grep_gate.py` — lazy-format logger gate (6 dirs as of #9). `tests/cli/test_exit_codes.py` — parametrized exception → exit-code contract. `tests/cli/test_5_surface_parity_select.py` — 5-surface parity for `--select` (issue #37 DEC-017).
+`plans/super/9-cli-entrypoint.md` — DEC-001 … DEC-027. `plans/super/37-multi-model-select.md` — DEC-001 … DEC-017 (multi-model batch additions). Issue #49 — `cmd_lint` manifest load + `--model` bare-name resolver. `src/signalforge/cli/` — current implementation. `docs/cli-ops.md` — operational reference. `tests/cli/` — in-process and subprocess test suite. `tests/test_audit_completeness.py::test_every_typed_error_is_in_exit_code_mapping_table` — 7th AST scan (DEC-024). `tests/llm/test_logger_grep_gate.py` — lazy-format logger gate (6 dirs as of #9). `tests/cli/test_exit_codes.py` — parametrized exception → exit-code contract. `tests/cli/test_5_surface_parity_select.py` — 5-surface parity for `--select` (issue #37 DEC-017). `tests/cli/test_lint.py::test_lint_resolves_model_*` — bare-name / unique_id / file-path forms (issue #49).
 
 See-Also: clauditor's `.claude/rules/llm-cli-exit-code-taxonomy.md` is the source of the four-tier rule; SignalForge ports it as one section inside this file rather than a standalone rule (DEC-009 of #9 — one rule file per pipeline layer).

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ austin:
 EOF
 ```
 
-### 5. Validate config (`signalforge lint`)
+### 5. Pre-flight check (`signalforge lint`)
 
-Before paying for an LLM call, run the config-only validator. It loads
+Before paying for an LLM call, run the pre-flight validator. It loads
 `signalforge.yml` (every per-stage block) and the dbt manifest — no
 warehouse calls, no Anthropic calls, no network — and reports every
 failure in one shot. Sub-second; catches typos like

--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@ EOF
 ### 5. Validate config (`signalforge lint`)
 
 Before paying for an LLM call, run the config-only validator. It loads
-`signalforge.yml`, the dbt manifest, and the warehouse profile through
-every per-stage loader — no warehouse calls, no Anthropic calls, no
-network — and reports every block that fails to parse in one shot.
-Sub-second; catches typos like `safety: { mdoel: ... }` that the
-`extra="forbid"` config models would otherwise surface only after a
-billable `generate` run:
+`signalforge.yml` (every per-stage block) and the dbt manifest — no
+warehouse calls, no Anthropic calls, no network — and reports every
+failure in one shot. Sub-second; catches typos like
+`safety: { mdoel: ... }` that the `extra="forbid"` config models would
+otherwise surface only after a billable `generate` run, plus manifest
+schema-version mismatches (e.g. dbt 1.13 → v13, outside the supported
+v9–v12 range) that would otherwise surface mid-pipeline:
 
 ```bash
 signalforge lint --project-dir /tmp/sf-austin

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -244,29 +244,62 @@ are documented per-stage in each layer's ops doc.
 ### `signalforge lint`
 
 Validate the five existing `signalforge.yml` config blocks (`safety:`,
-`llm:`, `prune:`, `grade:`, `diff:`) against their per-stage loaders.
-No warehouse, no LLM, no network — sub-second target. The natural
-pre-flight check operators run on every save.
+`llm:`, `prune:`, `grade:`, `diff:`) against their per-stage loaders,
+then load the dbt manifest. No warehouse, no LLM, no network —
+sub-second target. The natural pre-flight check operators run on every
+save.
 
 Flags:
 
 - `--config PATH` — Override the default
   `<project_dir>/signalforge.yml`. Path is canonicalised against
   the resolved project_dir.
+- `--manifest PATH` — Override the default
+  `<project_dir>/target/manifest.json`. Path is canonicalised against
+  the resolved project_dir and must stay inside it (no symlink
+  escapes).
+- `--model NAME` — Optional. Also resolve a model in the loaded
+  manifest and report whether it exists. Accepts three forms:
+  - **unique_id** — `model.<pkg>.<name>`
+  - **file path** — `models/path/to/<name>.sql`
+  - **bare name** — `<name>` (matches against `Model.name` across
+    enabled nodes via `Manifest.iter_models`; sidesteps the
+    `Manifest.get_model` gotcha that routes bare names through the
+    file-path branch). A bare name matching two or more enabled
+    models fails loud with a disambiguation list.
 - `--project-dir PATH` — Same semantics as `generate`'s flag
   (DEC-027 absolute assertion; walk-up applies only when the flag
   is omitted).
 
 Multi-error reporting (DEC-008): when more than one block fails,
 `lint` collects every failure and emits a header + bullet list rather
-than short-circuiting on the first. Stdout is silent on success
-(git-style); stderr carries the failures.
+than short-circuiting on the first. The header generalises to
+`ERROR: lint found N validation errors:` so manifest / model entries
+sit alongside the five config blocks under the same shape. Stdout is
+silent on success (git-style); stderr carries the failures.
+
+The manifest load is appended **after** the config loaders so the
+operator sees `signalforge.yml` typos AND a missing or
+schema-mismatched `target/manifest.json` in one run rather than fixing
+them one cascade at a time. Common manifest failures `lint` surfaces:
+
+| Symptom | Typed error | Exit tier | Fix |
+| --- | --- | --- | --- |
+| `target/manifest.json` is missing | `ManifestNotFoundError` | 1 (load) | Run `dbt parse` (or `dbt compile`) inside the project. |
+| Manifest schema is outside v9–v12 (e.g. dbt 1.13 → v13, Fusion → v20) | `UnsupportedManifestVersionError` | 1 (load) | Pin the project to a supported dbt version, or wait for the upstream tracking issue. |
+| `--model <name>` does not resolve | `ModelNotFoundError` / `ModelDisabledError` | 2 (input) | Check the spelling, or pass the unique_id (`model.<pkg>.<name>`) / file-path form. |
+
+`--model` resolution skips silently when the manifest load itself
+fails — the resolver depends on a loaded manifest and emitting a
+spurious second bullet would mislead the operator. The manifest entry
+alone surfaces.
 
 The Quick Start in [`README.md`](../README.md#5-validate-config-signalforge-lint)
 runs `signalforge lint` immediately after the fixture is prepared and
 before the first `signalforge generate` call — sub-second, free, and
-catches `extra="forbid"` typos (e.g. `safety: { mdoel: ... }`) that
-would otherwise surface only after a billable LLM round-trip.
+catches `extra="forbid"` typos (e.g. `safety: { mdoel: ... }`) plus
+the manifest-version / model-name mistakes that would otherwise
+surface only after a billable LLM round-trip.
 
 ### `signalforge version`
 

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -294,7 +294,7 @@ fails — the resolver depends on a loaded manifest and emitting a
 spurious second bullet would mislead the operator. The manifest entry
 alone surfaces.
 
-The Quick Start in [`README.md`](../README.md#5-validate-config-signalforge-lint)
+The Quick Start in [`README.md`](../README.md#5-pre-flight-check-signalforge-lint)
 runs `signalforge lint` immediately after the fixture is prepared and
 before the first `signalforge generate` call — sub-second, free, and
 catches `extra="forbid"` typos (e.g. `safety: { mdoel: ... }`) plus

--- a/src/signalforge/cli/lint.py
+++ b/src/signalforge/cli/lint.py
@@ -1,22 +1,31 @@
-"""``signalforge lint`` subcommand (US-004 — config-only validator).
+"""``signalforge lint`` subcommand — pre-flight pipeline validator.
 
 Validates the five existing ``signalforge.yml`` config blocks
 (``safety:``, ``llm:``, ``prune:``, ``grade:``, ``diff:``) against their
 per-stage loaders, then loads the dbt manifest (issue #49 — surfaces
 manifest-schema-version mismatches and missing ``target/manifest.json``
-as a pre-LLM-call failure). No warehouse, no LLM, no network —
-sub-second target.
+as a pre-LLM-call failure), and optionally resolves a model in the
+loaded manifest when ``--model <name>`` is supplied. No warehouse, no
+LLM, no network — sub-second target. Originally shipped as US-004 of
+issue #9 (config-only validator); broadened in issue #49 to cover the
+manifest seam.
 
 Multi-error reporting per DEC-008:
 
 * Zero loaders raise → exit 0 with silent stdout (git-style).
-* Exactly one loader raises → exit 1 with the canonical
-  ``ERROR: <message>`` single-line stderr shape.
-* Two or more loaders raise → exit 1 with a header + bullet list:
+* Exactly one loader raises → exit
+  ``map_exception_to_exit_code(exc)`` (typically tier 1 for
+  ``*ConfigNotFoundError`` / ``*ConfigInvalidError`` /
+  ``ManifestNotFoundError`` / ``UnsupportedManifestVersionError``;
+  tier 2 for ``ModelNotFoundError`` / ``CliInputError``) with the
+  canonical ``ERROR: <message>`` single-line stderr shape.
+* Two or more loaders raise → exit
+  ``max(map_exception_to_exit_code(exc) for ... in failures)`` (so the
+  most severe per-failure tier wins) with a header + bullet list:
 
   .. code-block:: text
 
-      ERROR: signalforge.yml has N validation errors:
+      ERROR: lint found N validation errors:
         - safety: <error msg>
         - prune:  <error msg>
         - manifest: <error msg>

--- a/src/signalforge/cli/lint.py
+++ b/src/signalforge/cli/lint.py
@@ -2,7 +2,10 @@
 
 Validates the five existing ``signalforge.yml`` config blocks
 (``safety:``, ``llm:``, ``prune:``, ``grade:``, ``diff:``) against their
-per-stage loaders. No warehouse, no LLM, no network — sub-second target.
+per-stage loaders, then loads the dbt manifest (issue #49 — surfaces
+manifest-schema-version mismatches and missing ``target/manifest.json``
+as a pre-LLM-call failure). No warehouse, no LLM, no network —
+sub-second target.
 
 Multi-error reporting per DEC-008:
 
@@ -16,10 +19,30 @@ Multi-error reporting per DEC-008:
       ERROR: signalforge.yml has N validation errors:
         - safety: <error msg>
         - prune:  <error msg>
+        - manifest: <error msg>
 
   This mirrors the DEC-008 tier-2 multi-violation shape used by the
   drafter's whole-draft anchor-contract error so CI parsers see one
   visual contract for any "list of problems" output the CLI emits.
+
+The manifest is loaded AFTER every config loader so the operator still
+sees ``signalforge.yml`` typos when ``target/manifest.json`` is also
+missing — both surface in the same run.
+
+When ``--model <name>`` is supplied, lint also resolves the model in
+the loaded manifest. Three forms are accepted:
+
+* ``unique_id`` form: ``model.<pkg>.<name>`` — routed to
+  :meth:`Manifest.get_model` directly.
+* file-path form: ``models/path/to/<name>.sql`` — routed to
+  :meth:`Manifest.get_model` directly.
+* bare-name form: ``<name>`` — looked up via :meth:`Manifest.iter_models`
+  matching on :attr:`Model.name`. The bare-name branch sidesteps the
+  ``Manifest.get_model`` gotcha (see ``testing-signal.md`` §
+  "Multi-surface drift") where bare names route to the file-path branch
+  and surface a confusing ``ModelNotFoundError`` even when the model
+  exists under a unique_id. A bare name matching two or more enabled
+  models raises :class:`ModelNotFoundError` with a disambiguation hint.
 
 Project-root resolution mirrors :mod:`signalforge.cli.generate`:
 
@@ -29,8 +52,9 @@ Project-root resolution mirrors :mod:`signalforge.cli.generate`:
   (DEC-001).
 
 The sub-second target is a smoke assertion in
-``tests/cli/test_lint.py``. The five loaders are pure YAML parse +
-Pydantic validation; nothing in this path opens a network connection or
+``tests/cli/test_lint.py``. The five config loaders are pure YAML parse
++ Pydantic validation; the manifest load is a single JSON parse +
+Pydantic validation. Nothing in this path opens a network connection or
 touches the warehouse.
 """
 
@@ -51,6 +75,13 @@ from signalforge.cli.errors import CliPathError
 from signalforge.diff import load_diff_config
 from signalforge.draft import load_draft_config
 from signalforge.grade import load_grade_config
+from signalforge.manifest import (
+    Manifest,
+    ManifestError,
+    Model,
+    ModelNotFoundError,
+)
+from signalforge.manifest import load as load_manifest
 from signalforge.prune import load_prune_config
 from signalforge.safety import load_safety_config
 
@@ -79,13 +110,15 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
     """Register the ``lint`` subcommand on the top-level parser."""
     parser = subparsers.add_parser(
         "lint",
-        help="Validate the signalforge.yml config blocks.",
+        help="Validate the signalforge.yml config blocks and the dbt manifest.",
         description=(
             "Validate the five signalforge.yml config blocks (safety, llm, "
-            "prune, grade, diff). Exits 0 when every block parses cleanly "
-            "(or is absent — each loader returns defaults silently per its "
-            "own DEC). On error, lists every failing block in one run "
-            "rather than short-circuiting on the first failure."
+            "prune, grade, diff) AND load the dbt manifest. Exits 0 when "
+            "every block parses cleanly (or is absent — each loader returns "
+            "defaults silently per its own DEC) AND the manifest loads "
+            "without error. On failure, lists every failing block in one "
+            "run rather than short-circuiting on the first failure. No "
+            "warehouse, no LLM, no network."
         ),
     )
     parser.add_argument(
@@ -95,6 +128,29 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         help=(
             "Override the default <project_dir>/signalforge.yml. Path is "
             "canonicalised against the resolved project_dir."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Override the default <project_dir>/target/manifest.json. Path "
+            "is canonicalised against the resolved project_dir and must "
+            "stay inside it (no symlink escapes)."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        metavar="NAME",
+        default=None,
+        help=(
+            "Optional: also resolve a model in the loaded manifest and "
+            "report whether it exists. Accepts three forms: a unique_id "
+            "(model.<pkg>.<name>), a file path "
+            "(models/path/to/<name>.sql), or a bare model name (<name>). "
+            "Bare names match against Model.name across enabled nodes and "
+            "fail loud if two or more models share the name."
         ),
     )
     parser.add_argument(
@@ -161,8 +217,55 @@ def _resolve_project_dir(args: argparse.Namespace) -> Path:
     )
 
 
+def _resolve_model_for_lint(manifest: Manifest, key: str) -> Model:
+    """Resolve ``key`` to a :class:`Model` across all three input shapes.
+
+    * ``key.startswith("model.")`` → unique_id branch via
+      :meth:`Manifest.get_model`.
+    * ``"/" in key`` or ``key.endswith(".sql")`` → file-path branch via
+      :meth:`Manifest.get_model`.
+    * Else → bare-name branch: scan :meth:`Manifest.iter_models` for
+      ``Model.name == key``. One match returns the model; zero matches
+      raises :class:`ModelNotFoundError` with a hint suggesting the
+      unique_id / file-path form; multiple matches raises
+      :class:`ModelNotFoundError` with a disambiguation list (capped at
+      five unique_ids to keep stderr readable).
+
+    The bare-name branch sidesteps the ``Manifest.get_model`` gotcha
+    pinned by ``testing-signal.md`` § "Multi-surface drift on user-facing
+    model arguments" where bare names route through the file-path branch
+    and surface a confusing ``ModelNotFoundError`` even when the model
+    exists under its unique_id.
+    """
+    if key.startswith("model.") or "/" in key or key.endswith(".sql"):
+        return manifest.get_model(key)
+
+    matches = [m for m in manifest.iter_models() if m.name == key]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        sample = ", ".join(m.unique_id for m in matches[:5])
+        more = f" (+{len(matches) - 5} more)" if len(matches) > 5 else ""
+        raise ModelNotFoundError(
+            f"Bare model name {key!r} matches {len(matches)} enabled models: {sample}{more}",
+            remediation=(
+                "Disambiguate by passing the full unique_id "
+                "(model.<pkg>.<name>) or the file path "
+                "(models/path/to/<name>.sql)."
+            ),
+        )
+    raise ModelNotFoundError(
+        f"No enabled model with name {key!r} in the manifest.",
+        remediation=(
+            "Check the model name spelling, or pass the unique_id form "
+            "(model.<pkg>.<name>) / file path (models/path/to/<name>.sql). "
+            "Disabled models do not match bare-name lookup."
+        ),
+    )
+
+
 def cmd_lint(args: argparse.Namespace) -> int:
-    """Validate every config block and report all failures in one run.
+    """Validate every config block + the manifest and report all failures in one run.
 
     Returns the integer exit code per the four-tier CLI taxonomy
     (DEC-008). Every loader failure routes through
@@ -170,19 +273,29 @@ def cmd_lint(args: argparse.Namespace) -> int:
     exception would produce from ``cmd_generate``:
 
     * ``0`` — every loader returned cleanly (or returned defaults silently
-      because the block / file was absent).
+      because the block / file was absent) AND the manifest loaded
+      cleanly AND, if ``--model <name>`` was supplied, the model
+      resolved.
     * single failure → :func:`map_exception_to_exit_code` of the
       exception (typically tier 1 for ``*ConfigNotFoundError`` /
-      ``*ConfigInvalidError``; tier 2 for ``CliInputError``).
+      ``*ConfigInvalidError`` / ``ManifestNotFoundError`` /
+      ``UnsupportedManifestVersionError``; tier 2 for
+      ``ModelNotFoundError`` / ``ModelDisabledError`` / ``CliInputError``).
     * multiple failures → ``max(...)`` of the per-failure tiers, rendered
       with the multi-error header + bullets shape (DEC-008).
     * project-root / path-canonicalisation failures from the CLI layer
       itself route through the same mapper (typically tier 1 for
       ``CliPathError``, tier 2 for ``CliInputError``).
+
+    The manifest load is intentionally appended AFTER every config loader
+    so the operator sees ``signalforge.yml`` typos AND a missing /
+    schema-mismatched ``target/manifest.json`` in one run rather than
+    fixing them one cascade at a time.
     """
     try:
         project_dir = _resolve_project_dir(args)
         config_path = canonicalise_user_path(args.config, project_dir)
+        manifest_path = canonicalise_user_path(getattr(args, "manifest", None), project_dir)
     except Exception as exc:  # noqa: BLE001 — uniform CLI boundary catch (DEC-016)
         message = format_error_to_stderr(exc)
         print(message, file=sys.stderr)
@@ -199,6 +312,25 @@ def cmd_lint(args: argparse.Namespace) -> int:
             loader(project_dir, config_path)  # type: ignore[operator]
         except Exception as exc:  # noqa: BLE001 — collect every typed error
             failures.append((block_name, exc))
+
+    # Issue #49 — manifest load + optional model resolution. We attempt
+    # both regardless of whether config loaders failed (multi-error
+    # reporting prefers showing every problem in one run); a manifest
+    # failure adds one more entry to ``failures``. The model-resolution
+    # step only runs when the manifest loaded successfully, since a
+    # missing/invalid manifest makes model lookup undefined.
+    manifest_obj: Manifest | None = None
+    try:
+        manifest_obj = load_manifest(project_dir, manifest_path=manifest_path)
+    except ManifestError as exc:
+        failures.append(("manifest", exc))
+
+    model_arg = getattr(args, "model", None)
+    if model_arg is not None and manifest_obj is not None:
+        try:
+            _resolve_model_for_lint(manifest_obj, model_arg)
+        except ManifestError as exc:
+            failures.append(("model", exc))
 
     if not failures:
         return 0
@@ -221,7 +353,10 @@ def cmd_lint(args: argparse.Namespace) -> int:
     # Value error, must be positive ..."``); we collapse those into a
     # single line so the bullet shape stays one ``  - <block>: <msg>``
     # row per failure — CI parsers key on the leading two-space dash.
-    header = f"ERROR: signalforge.yml has {len(failures)} validation errors:"
+    # The header generalises to "lint found N validation errors" — covers
+    # both ``signalforge.yml`` blocks and the manifest / model entries
+    # added by issue #49.
+    header = f"ERROR: lint found {len(failures)} validation errors:"
     bullets: list[str] = []
     for block_name, exc in failures:
         # Use the typed error's ``message`` attribute if present (every

--- a/tests/cli/_factories.py
+++ b/tests/cli/_factories.py
@@ -2,13 +2,17 @@
 
 Two helpers:
 
-* :func:`make_fake_dbt_project` — drops a minimal ``dbt_project.yml`` and
-  an empty ``target/`` dir under ``tmp_path`` and returns the project
-  root. The CLI's project-root resolver (`_resolve_project_dir`) is
-  satisfied by the presence of ``dbt_project.yml``; the CLI's pipeline
-  is patched out at the stage-entry boundary, so the manifest /
-  warehouse / draft / prune / grade / diff stages never read from
-  these paths.
+* :func:`make_fake_dbt_project` — drops a minimal ``dbt_project.yml``, an
+  empty ``target/`` dir, and a minimal ``target/manifest.json`` under
+  ``tmp_path`` and returns the project root. The CLI's project-root
+  resolver (`_resolve_project_dir`) is satisfied by the presence of
+  ``dbt_project.yml``; the CLI's pipeline is patched out at the
+  stage-entry boundary, so the manifest / warehouse / draft / prune /
+  grade / diff stages never read from these paths during a
+  ``cmd_generate`` test. The bundled manifest exists so the new
+  ``cmd_lint`` manifest-load step (issue #49) finds a parseable file
+  rather than tripping :class:`ManifestNotFoundError` on every test.
+  Suppress it with ``with_manifest=False``.
 * :func:`make_typed_stage_returns` — produces typed-but-trivial return
   values (a :class:`Manifest` containing one :class:`Model`, a
   :class:`CandidateSchema`, a :class:`PruneResult`, a
@@ -21,6 +25,7 @@ Lives under ``tests/cli/`` and is never imported from production code.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -42,19 +47,48 @@ target-path: target
 """
 
 
-def make_fake_dbt_project(tmp_path: Path, name: str = "project") -> Path:
+_MINIMAL_MANIFEST: dict[str, object] = {
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+    },
+    "nodes": {},
+    "disabled": {},
+}
+"""Smallest manifest the loader accepts. ``nodes`` and ``disabled`` are
+empty so :func:`signalforge.manifest.load` constructs a :class:`Manifest`
+with no models. Tests that need real models extend this manifest by
+writing their own ``target/manifest.json`` (see
+:func:`tests.cli.test_lint.test_lint_resolves_model_*`)."""
+
+
+def make_fake_dbt_project(
+    tmp_path: Path,
+    name: str = "project",
+    *,
+    with_manifest: bool = True,
+) -> Path:
     """Create a minimal dbt project layout under ``tmp_path / name``.
 
-    Drops ``dbt_project.yml`` (so ``_resolve_project_dir`` is satisfied)
-    and an empty ``target/`` dir. Does NOT write a manifest.json — every
-    test that exercises ``cmd_generate`` patches ``manifest.load`` so
-    the on-disk file is never opened.
+    Drops ``dbt_project.yml`` (so ``_resolve_project_dir`` is satisfied),
+    an empty ``target/`` dir, and (when ``with_manifest=True``, the
+    default) a minimal ``target/manifest.json`` with zero models and the
+    v12 schema URL. The manifest lets ``cmd_lint``'s issue-#49
+    manifest-load step find a parseable file; ``cmd_generate`` tests
+    patch :func:`signalforge.manifest.load` and don't care.
+
+    Pass ``with_manifest=False`` to exercise the ``ManifestNotFoundError``
+    branch.
     """
     project_dir = tmp_path / name
     project_dir.mkdir(parents=True, exist_ok=True)
     (project_dir / "dbt_project.yml").write_text(_DBT_PROJECT_YML, encoding="utf-8")
     (project_dir / "target").mkdir(exist_ok=True)
     (project_dir / ".signalforge").mkdir(exist_ok=True)
+    if with_manifest:
+        (project_dir / "target" / "manifest.json").write_text(
+            json.dumps(_MINIMAL_MANIFEST),
+            encoding="utf-8",
+        )
     return project_dir
 
 

--- a/tests/cli/test_lint.py
+++ b/tests/cli/test_lint.py
@@ -21,6 +21,7 @@ so the suite stays under the sub-second target on every fixture.
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from pathlib import Path
@@ -29,6 +30,41 @@ import pytest
 
 from signalforge.cli import main
 from tests.cli._factories import make_fake_dbt_project
+
+
+def _manifest_with_models(unique_ids_and_names: list[tuple[str, str]]) -> dict[str, object]:
+    """Build a minimal dbt manifest dict containing the supplied models.
+
+    Each tuple is ``(unique_id, name)``; the helper expands to a node
+    with the structural fields :class:`signalforge.manifest.models.Model`
+    requires (resource_type, package_name, raw_code, schema, columns).
+    Used by the model-resolution lint tests (issue #49). ``raw_code``
+    is a no-op SELECT so :class:`ModelMissingSqlError` never fires.
+    """
+    nodes: dict[str, object] = {}
+    for unique_id, name in unique_ids_and_names:
+        # unique_id is canonically ``model.<pkg>.<name>``.
+        parts = unique_id.split(".")
+        pkg = parts[1] if len(parts) >= 3 else "pkg"
+        nodes[unique_id] = {
+            "unique_id": unique_id,
+            "name": name,
+            "resource_type": "model",
+            "package_name": pkg,
+            "original_file_path": f"models/{name}.sql",
+            "path": f"{name}.sql",
+            "database": "fake_db",
+            "schema": "fake_schema",
+            "raw_code": f"select 1 as id -- {name}",
+            "columns": {},
+        }
+    return {
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+        },
+        "nodes": nodes,
+        "disabled": {},
+    }
 
 
 def _capture(capsys: pytest.CaptureFixture[str]) -> tuple[str, str]:
@@ -195,10 +231,13 @@ def test_lint_multiple_invalid_blocks_lists_all(
 
     assert code == 2, f"expected exit 2 (max per-failure tier); got {code}; stderr={err!r}"
     # Header + 3 bullets shape per DEC-008 (multi-error). The regex pins
-    # "ERROR: signalforge.yml has 3 validation errors:" + at least three
+    # "ERROR: lint found 3 validation errors:" + at least three
     # ``  - <block>: <msg>`` bullets, each with a non-empty message body.
+    # The header text generalised from "signalforge.yml has..." to
+    # "lint found..." in issue #49 so the same shape covers manifest /
+    # model entries alongside the five config blocks.
     pattern = (
-        r"^ERROR: signalforge\.yml has 3 validation errors:\n"
+        r"^ERROR: lint found 3 validation errors:\n"
         r"  - \S+: .+\n  - \S+: .+\n  - \S+: .+"
     )
     assert re.search(pattern, err), (
@@ -254,7 +293,8 @@ def test_lint_completes_subsecond(
     """Performance smoke: happy-path ``lint`` runs in well under a second.
 
     The five loaders are pure YAML parse + Pydantic validation against a
-    small file, so the wall-clock budget is generous. The 1.0 s threshold
+    small file; the manifest load is a single JSON parse + Pydantic
+    validation against the minimal fixture manifest. The 1.0 s threshold
     catches a regression where a future refactor accidentally wires a
     network / warehouse call into the lint path.
     """
@@ -268,3 +308,328 @@ def test_lint_completes_subsecond(
 
     assert code == 0
     assert elapsed < 1.0, f"lint took {elapsed:.3f}s; expected sub-second"
+
+
+# ---------------------------------------------------------------------------
+# Issue #49 — manifest load + --model resolution
+# ---------------------------------------------------------------------------
+
+
+def test_lint_reports_missing_manifest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No ``target/manifest.json`` → exit 1; stderr names the manifest block.
+
+    Builds a fake project with ``with_manifest=False`` so the loader
+    surfaces :class:`ManifestNotFoundError` (tier 1). The config blocks
+    parse cleanly so the manifest is the sole failure and the
+    single-error stderr shape fires.
+    """
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    # No signalforge.yml either — every config loader returns defaults.
+
+    code = main(["lint", "--project-dir", str(project_dir)])
+    _out, err = _capture(capsys)
+
+    assert code == 1, f"expected exit 1 (load tier); got {code}; stderr={err!r}"
+    assert err.startswith("ERROR:")
+    # Single-error shape uses the typed error's own message directly.
+    assert "manifest" in err.lower() or "target" in err.lower()
+    assert "Traceback" not in err
+
+
+def test_lint_reports_unsupported_manifest_version(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Manifest v20 (Fusion / unsupported) → exit 1 with a clear message.
+
+    Writes a manifest with ``dbt_schema_version: v20.json`` — outside
+    the v9–v12 supported range. The loader raises
+    :class:`UnsupportedManifestVersionError` (tier 1).
+    """
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    manifest_path = project_dir / "target" / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v20.json",
+                },
+                "nodes": {},
+                "disabled": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code = main(["lint", "--project-dir", str(project_dir)])
+    _out, err = _capture(capsys)
+
+    assert code == 1, f"expected exit 1; got {code}; stderr={err!r}"
+    assert err.startswith("ERROR:")
+    assert "v9" in err or "schema" in err.lower() or "version" in err.lower()
+    assert "Traceback" not in err
+
+
+def test_lint_config_and_manifest_failures_both_listed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bad ``safety:`` block AND missing manifest → both in the bullet list.
+
+    The header generalised from "signalforge.yml has N validation errors"
+    to "lint found N validation errors" in issue #49 so the same shape
+    covers manifest entries alongside the five config blocks.
+    """
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    _write_signalforge_yml(project_dir, _INVALID_SAFETY_MODE)
+
+    code = main(["lint", "--project-dir", str(project_dir)])
+    _out, err = _capture(capsys)
+
+    # safety is tier 2 (input), manifest is tier 1 (load); max = 2.
+    assert code == 2, f"expected exit 2 (max of safety=2, manifest=1); got {code}; stderr={err!r}"
+    assert err.startswith("ERROR: lint found 2 validation errors:")
+    assert "safety" in err
+    assert "manifest" in err
+    assert "Traceback" not in err
+
+
+def test_lint_resolves_model_by_unique_id(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--model model.shop.customers`` resolves cleanly → exit 0; silent stdout."""
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    (project_dir / "target" / "manifest.json").write_text(
+        json.dumps(_manifest_with_models([("model.shop.customers", "customers")])),
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "lint",
+            "--project-dir",
+            str(project_dir),
+            "--model",
+            "model.shop.customers",
+        ]
+    )
+    out, err = _capture(capsys)
+
+    assert code == 0, f"expected exit 0; got {code}; stderr={err!r}"
+    assert out == ""
+    assert "Traceback" not in err
+
+
+def test_lint_resolves_model_by_bare_name(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--model customers`` (bare name) resolves via iter_models → exit 0.
+
+    Pinned by the testing-signal.md "Multi-surface drift" gotcha: bare
+    names route through ``Manifest.get_model``'s file-path branch and
+    raise ``ModelNotFoundError`` even when a model with that name
+    exists. The bare-name handler scans :meth:`Manifest.iter_models` and
+    sidesteps the gotcha for the operator.
+    """
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    (project_dir / "target" / "manifest.json").write_text(
+        json.dumps(_manifest_with_models([("model.shop.customers", "customers")])),
+        encoding="utf-8",
+    )
+
+    code = main(["lint", "--project-dir", str(project_dir), "--model", "customers"])
+    out, err = _capture(capsys)
+
+    assert code == 0, f"expected exit 0 for bare-name lookup; got {code}; stderr={err!r}"
+    assert out == ""
+    assert "Traceback" not in err
+
+
+def test_lint_resolves_model_by_file_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--model models/customers.sql`` resolves via the file-path branch."""
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    (project_dir / "target" / "manifest.json").write_text(
+        json.dumps(_manifest_with_models([("model.shop.customers", "customers")])),
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "lint",
+            "--project-dir",
+            str(project_dir),
+            "--model",
+            "models/customers.sql",
+        ]
+    )
+    out, err = _capture(capsys)
+
+    assert code == 0, f"expected exit 0; got {code}; stderr={err!r}"
+    assert out == ""
+
+
+def test_lint_model_not_found_exits_two(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--model nonexistent`` → exit 2; stderr names the missing model.
+
+    ``ModelNotFoundError`` is tier 2 (input — operator-supplied data is
+    wrong).
+    """
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    (project_dir / "target" / "manifest.json").write_text(
+        json.dumps(_manifest_with_models([("model.shop.customers", "customers")])),
+        encoding="utf-8",
+    )
+
+    code = main(["lint", "--project-dir", str(project_dir), "--model", "ghosts"])
+    _out, err = _capture(capsys)
+
+    assert code == 2, f"expected exit 2 (input tier); got {code}; stderr={err!r}"
+    assert err.startswith("ERROR:")
+    assert "ghosts" in err
+    assert "Traceback" not in err
+
+
+def test_lint_bare_model_name_ambiguous_disambiguates(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Two enabled models share a name → exit 2; stderr lists the unique_ids.
+
+    Bare-name lookup fails loud when multiple packages register a model
+    with the same name; the remediation tells the operator to pass the
+    unique_id or file path.
+    """
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    (project_dir / "target" / "manifest.json").write_text(
+        json.dumps(
+            _manifest_with_models(
+                [
+                    ("model.shop.customers", "customers"),
+                    ("model.finance.customers", "customers"),
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    code = main(["lint", "--project-dir", str(project_dir), "--model", "customers"])
+    _out, err = _capture(capsys)
+
+    assert code == 2, f"expected exit 2; got {code}; stderr={err!r}"
+    assert err.startswith("ERROR:")
+    assert "model.shop.customers" in err
+    assert "model.finance.customers" in err
+    assert "Traceback" not in err
+
+
+def test_lint_model_flag_skipped_when_manifest_fails(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Manifest fails to load → model resolution is silently skipped.
+
+    Only the manifest failure surfaces; no spurious second bullet for a
+    model lookup we couldn't perform (the manifest is the dependency).
+    """
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    # No manifest.json on disk; --model would be undefined.
+
+    code = main(["lint", "--project-dir", str(project_dir), "--model", "customers"])
+    _out, err = _capture(capsys)
+
+    assert code == 1, f"expected exit 1 (manifest tier); got {code}; stderr={err!r}"
+    # Single-error shape — only the manifest entry surfaces.
+    assert err.startswith("ERROR:")
+    assert "model" not in err.lower().split("\n")[0] or "manifest" in err.lower()
+    # Header line refers to the manifest, not a "2 validation errors"
+    # multi-error header.
+    assert "validation errors:" not in err.split("\n")[0]
+
+
+def test_lint_manifest_path_override(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--manifest <path>`` reads the override location rather than the default."""
+    project_dir = make_fake_dbt_project(tmp_path, with_manifest=False)
+    custom = project_dir / "alt_manifest.json"
+    custom.write_text(
+        json.dumps(_manifest_with_models([("model.shop.customers", "customers")])),
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "lint",
+            "--project-dir",
+            str(project_dir),
+            "--manifest",
+            str(custom),
+            "--model",
+            "customers",
+        ]
+    )
+    _out, err = _capture(capsys)
+
+    assert code == 0, f"expected exit 0; got {code}; stderr={err!r}"
+    assert "Traceback" not in err
+
+
+def test_lint_makes_no_llm_or_warehouse_call(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #49 AC: lint never calls the Anthropic API or any warehouse client.
+
+    We patch the constructors / SDK seams so any accidental wiring would
+    raise loudly. The lint run must complete (exit 0) because none of
+    those paths are touched.
+    """
+    project_dir = make_fake_dbt_project(tmp_path)
+    _write_signalforge_yml(project_dir, _VALID_ALL_BLOCKS)
+
+    # Any attempt to construct an Anthropic client would call this
+    # factory; raising here proves no LLM seam was reached. The grep
+    # for ``_make_anthropic_client`` mirrors the SDK confinement in
+    # ``signalforge.llm._client``.
+    def _explode(*args: object, **kwargs: object) -> object:
+        raise AssertionError("lint must not invoke the LLM seam")
+
+    import signalforge.llm._client as _llm_client
+
+    monkeypatch.setattr(_llm_client, "_make_anthropic_client", _explode)
+
+    # The warehouse adapter's BigQuery shim would be touched only via
+    # ``from_profile`` or direct instantiation; both should stay
+    # untouched. Patch the factory to fail loud.
+    import signalforge.warehouse.base as _warehouse_base
+
+    monkeypatch.setattr(
+        _warehouse_base.WarehouseAdapter,
+        "from_profile",
+        classmethod(lambda cls, profile: _explode()),
+    )
+
+    code = main(["lint", "--project-dir", str(project_dir), "--model", "anything"])
+    _out, err = _capture(capsys)
+
+    # Model lookup against an empty manifest fails (tier 2) — that's
+    # fine; the assertion is that the lint flow never reached the LLM
+    # or warehouse seams (their _explode patches would have raised
+    # AssertionError instead, which propagates as a tier-1 panic-path
+    # tier and stderr would carry a different message).
+    assert code in {0, 2}, f"unexpected exit {code}; stderr={err!r}"
+    assert "must not invoke" not in err, "lint reached an LLM/warehouse seam"
+    assert "Traceback" not in err


### PR DESCRIPTION
Closes #49.

## Summary

- `signalforge lint` now loads the dbt manifest after the five config loaders, surfacing manifest-schema-version mismatches (e.g. dbt 1.13 → v13, Fusion → v20) and missing `target/manifest.json` as pre-LLM-call failures rather than mid-pipeline ones.
- New `--manifest PATH` flag (mirrors `generate`'s; symlink-hardened canonicalisation).
- New `--model NAME` flag accepts three forms — unique_id, file path, or **bare name**. The bare-name branch sidesteps the `Manifest.get_model` gotcha pinned by `testing-signal.md` (bare names route through the file-path branch and `ModelNotFoundError` even when the model exists). Multiple matches fail loud with a disambiguation list.
- Multi-error header generalised from `"signalforge.yml has N validation errors"` to `"lint found N validation errors"` so manifest / model entries sit alongside config blocks under one shape.
- No LLM call. No warehouse query. Pinned by `test_lint_makes_no_llm_or_warehouse_call` (patches the Anthropic factory + `WarehouseAdapter.from_profile` to fail loud).

## Acceptance criteria (from #49)

- [x] `signalforge lint` reports manifest-load failures (file missing, schema version unsupported, JSON parse).
- [x] Optional `--model <name>` flag reports model-existence (bare-name + unique_id + filepath forms).
- [x] No LLM `messages.create` call; no warehouse `query` call.
- [x] `docs/cli-ops.md` § `lint` updated per 5-surface parity (cli-layer.md).

## 5-surface parity

| Surface | Updated in |
| --- | --- |
| argparse help | `src/signalforge/cli/lint.py` (`--manifest`, `--model`) |
| handler docstring | `cmd_lint`'s docstring |
| ops doc | `docs/cli-ops.md` § `signalforge lint` (new manifest failure table + `--model` form table) |
| tests | `tests/cli/test_lint.py` (11 new tests) |
| ticket / README | Issue #49; README's stale "warehouse profile" claim trimmed |

## Test plan

- [x] `pytest tests/cli/test_lint.py --no-cov` — 19 passed (8 original + 11 new)
- [x] `ruff check . && ruff format --check . && pyright` — clean
- [x] Full `pytest` — 1665 passed; 6 pre-existing symlink-loop failures on `dev` are unrelated to this change (verified by stashing the diff and re-running)

## Surfaces NOT touched

- The warehouse-profile load remains out of scope per the issue (the README mention was stale; it's been trimmed). Natural follow-up ticket if/when that scope is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `signalforge lint` now loads and validates the dbt manifest (target/manifest.json)
  * Added `--model` flag to resolve specific models from the manifest
  * Added `--manifest` flag to override manifest location
  * Model lookup supports unique ID, file path, and bare name matching

* **Documentation**
  * Updated CLI documentation to describe manifest validation and model resolution behavior

* **Tests**
  * Expanded test coverage for new manifest loading and model resolution features

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->