### PR TITLE
53: PostgresAdapter stub to validate the warehouse-agnostic seam

### DIFF
--- a/.claude/rules/warehouse-adapters.md
+++ b/.claude/rules/warehouse-adapters.md
@@ -15,11 +15,14 @@ src/signalforge/warehouse/
   _path_safety.py        # symlink-hardened path canonicalisation (warehouse copy)
   _test_result_repr.py   # deterministic compact_repr for sample failures
   adapters/
-    bigquery.py          # the only concrete adapter in v0.1
+    bigquery.py          # the v0.1 concrete adapter
+    postgres.py          # v0.2 stub (issue #53) — validates the warehouse-agnostic seam
     _client.py           # pyright-noise shim around google.cloud.bigquery
 ```
 
 The ABC is warehouse-agnostic. v0.2 Snowflake/Postgres slot under `adapters/` without restructuring (DEC-001). `_`-prefixed helpers stay reachable via dotted import but are absent from the package namespace.
+
+**Second-adapter stub lives at `adapters/postgres.py`; lights up the v0.2 work (issue #53).** The stub implements only `__init__` (capturing connection params) and `dialect()` (returning a Postgres-flavoured `Dialect`: `quote_char='"'`, `identifier_case='lower'`, `supports_qualify=False`); every other abstract method raises `NotImplementedError("…issue #53…")`. `WarehouseAdapter.from_profile` dispatches `profile.type == "postgres"` to it so an operator with a Postgres profile sees a `NotImplementedError` rather than the v0.1 `UnsupportedProfileTypeError`. The stub exists to verify Architectural Commitment #3 ("warehouse-agnostic by design") by forcing the ABC + factory seam through a second code path right now — pre-#53 the only concrete was `bigquery.py` and the abstraction was unverified. When the v0.2 Postgres implementation lands it should replace every `NotImplementedError` with the real call (and likely extend `DbtProfileTarget` to accept Postgres-specific fields — the current `extra="forbid"` model is BigQuery-shaped).
 
 ## ABC + lazy-import factory (DEC-019)
 

--- a/src/signalforge/warehouse/__init__.py
+++ b/src/signalforge/warehouse/__init__.py
@@ -49,6 +49,7 @@ from signalforge.warehouse.errors import (
 )
 from signalforge.warehouse.models import (
     BIGQUERY_DIALECT,
+    POSTGRES_DIALECT,
     ColumnStats,
     Dialect,
     PartitionFilter,
@@ -75,6 +76,7 @@ __all__ = [
     "ManifestSchemaNotFoundError",
     "MaterialisationFailedError",
     "MaterialisationNotSupportedError",
+    "POSTGRES_DIALECT",
     "PartitionFilter",
     "ProfileEnvVarUnsetError",
     "ProfileNotFoundError",

--- a/src/signalforge/warehouse/adapters/postgres.py
+++ b/src/signalforge/warehouse/adapters/postgres.py
@@ -12,10 +12,15 @@ Snowflake implementation later.
 Scope (deliberately minimal):
 
 * :meth:`__init__` captures connection params for forward-compat.
-* :meth:`dialect` returns a Postgres-flavoured :class:`Dialect`
-  (``quote_char='"'``, ``identifier_case='lower'``,
-  ``supports_qualify=False``).
-* Every other abstract method on :class:`WarehouseAdapter` raises a clear
+* :meth:`__enter__` / :meth:`__exit__` are implemented as no-ops so the
+  ``with adapter:`` contract from
+  :class:`signalforge.warehouse.base.WarehouseAdapter` works without
+  conditional logic at the call site.
+* :meth:`dialect` returns the :data:`POSTGRES_DIALECT` constant from
+  :mod:`signalforge.warehouse.models` (``quote_char='"'``,
+  ``identifier_case='lower'``, ``supports_qualify=False``).
+* The three warehouse-operation methods (:meth:`sample_rows`,
+  :meth:`column_stats`, :meth:`run_test_sql`) raise
   :class:`NotImplementedError` naming this ticket (#53) so the v0.2
   implementation work has a single grep target.
 * :meth:`WarehouseAdapter.from_profile` dispatches ``profile.type ==
@@ -42,29 +47,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from signalforge.warehouse.base import WarehouseAdapter
-from signalforge.warehouse.models import ColumnStats, Dialect, TestResult
+from signalforge.warehouse.models import POSTGRES_DIALECT, ColumnStats, Dialect, TestResult
 
 if TYPE_CHECKING:
     from signalforge.warehouse.models import PartitionFilter, TableRef
-
-
-POSTGRES_DIALECT = Dialect(
-    name="postgres",
-    supports_tablesample=True,
-    supports_qualify=False,
-    quote_char='"',
-    identifier_case="lower",
-)
-"""Postgres-flavoured :class:`Dialect`.
-
-* ``quote_char='"'`` — Postgres uses double-quote for identifier quoting.
-* ``identifier_case='lower'`` — unquoted identifiers are folded to
-  lowercase (matches Postgres's own SQL parser behaviour).
-* ``supports_qualify=False`` — Postgres has no ``QUALIFY`` clause.
-* ``supports_tablesample=True`` — ``TABLESAMPLE`` is supported (BERNOULLI
-  / SYSTEM), though the prune layer prefers deterministic hash-mod
-  sampling anyway (DEC-006 of issue #3).
-"""
 
 
 _V02_REMEDIATION = "PostgresAdapter is a v0.2 stub (issue #53) — full implementation pending."

--- a/src/signalforge/warehouse/adapters/postgres.py
+++ b/src/signalforge/warehouse/adapters/postgres.py
@@ -1,0 +1,125 @@
+"""Postgres adapter — v0.2 stub (issue #53).
+
+The stub exists to validate the warehouse-agnostic seam — Architectural
+Commitment #3 of ``CLAUDE.md``. Pre-#53 the only concrete adapter was
+:class:`signalforge.warehouse.adapters.bigquery.BigQueryAdapter`; the
+``WarehouseAdapter`` ABC and the ``Dialect`` value object's claim to be
+"warehouse-agnostic by design" was *unverified* by a second adapter. This
+module forces the ABC + factory seam through a second code path right
+now so a v0.2 leak surfaces here instead of during a real Postgres /
+Snowflake implementation later.
+
+Scope (deliberately minimal):
+
+* :meth:`__init__` captures connection params for forward-compat.
+* :meth:`dialect` returns a Postgres-flavoured :class:`Dialect`
+  (``quote_char='"'``, ``identifier_case='lower'``,
+  ``supports_qualify=False``).
+* Every other abstract method on :class:`WarehouseAdapter` raises a clear
+  :class:`NotImplementedError` naming this ticket (#53) so the v0.2
+  implementation work has a single grep target.
+* :meth:`WarehouseAdapter.from_profile` dispatches ``profile.type ==
+  "postgres"`` here so an operator with a Postgres profile sees a
+  ``NotImplementedError`` rather than the v0.1
+  :class:`UnsupportedProfileTypeError`.
+
+What this stub does NOT do:
+
+* Real Postgres connectivity. No psycopg / asyncpg / SQLAlchemy import.
+* Extend :class:`DbtProfileTarget` to accept Postgres-specific fields
+  (``host`` / ``port`` / ``user`` / ``password`` / ``dbname``). The
+  current profile model is BigQuery-shaped (``extra="forbid"``); a real
+  Postgres adapter will need to relax or split it. That work belongs to
+  the v0.2 ticket.
+
+When the v0.2 implementation lands, replace every ``NotImplementedError``
+with the real adapter call and update ``adapters/_client.py`` (or its
+Postgres sibling) for any pyright-ignore confinement.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from signalforge.warehouse.base import WarehouseAdapter
+from signalforge.warehouse.models import ColumnStats, Dialect, TestResult
+
+if TYPE_CHECKING:
+    from signalforge.warehouse.models import PartitionFilter, TableRef
+
+
+POSTGRES_DIALECT = Dialect(
+    name="postgres",
+    supports_tablesample=True,
+    supports_qualify=False,
+    quote_char='"',
+    identifier_case="lower",
+)
+"""Postgres-flavoured :class:`Dialect`.
+
+* ``quote_char='"'`` — Postgres uses double-quote for identifier quoting.
+* ``identifier_case='lower'`` — unquoted identifiers are folded to
+  lowercase (matches Postgres's own SQL parser behaviour).
+* ``supports_qualify=False`` — Postgres has no ``QUALIFY`` clause.
+* ``supports_tablesample=True`` — ``TABLESAMPLE`` is supported (BERNOULLI
+  / SYSTEM), though the prune layer prefers deterministic hash-mod
+  sampling anyway (DEC-006 of issue #3).
+"""
+
+
+_V02_REMEDIATION = "PostgresAdapter is a v0.2 stub (issue #53) — full implementation pending."
+
+
+class PostgresAdapter(WarehouseAdapter):
+    """Stub :class:`WarehouseAdapter` for Postgres profiles.
+
+    Forward-compat only; every method other than :meth:`__init__` and
+    :meth:`dialect` raises :class:`NotImplementedError`.
+    """
+
+    def __init__(
+        self,
+        *,
+        dbname: str | None = None,
+        schema: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        user: str | None = None,
+        password: str | None = None,
+    ) -> None:
+        self._dbname = dbname
+        self._schema = schema
+        self._host = host
+        self._port = port
+        self._user = user
+        self._password = password
+
+    def __repr__(self) -> str:
+        return f"PostgresAdapter(dbname={self._dbname!r}, schema={self._schema!r})"
+
+    def __enter__(self) -> WarehouseAdapter:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    def dialect(self) -> Dialect:
+        return POSTGRES_DIALECT
+
+    def sample_rows(
+        self,
+        table: TableRef,
+        n: int,
+        *,
+        partition_filter: PartitionFilter | None = None,
+    ) -> list[dict]:
+        raise NotImplementedError(f"sample_rows: {_V02_REMEDIATION}")
+
+    def column_stats(self, table: TableRef, column: str) -> ColumnStats:
+        raise NotImplementedError(f"column_stats: {_V02_REMEDIATION}")
+
+    def run_test_sql(self, sql: str, *, capture_failures: int = 0) -> TestResult:
+        raise NotImplementedError(f"run_test_sql: {_V02_REMEDIATION}")
+
+
+__all__ = ["POSTGRES_DIALECT", "PostgresAdapter"]

--- a/src/signalforge/warehouse/base.py
+++ b/src/signalforge/warehouse/base.py
@@ -4,12 +4,16 @@ The ABC contract is warehouse-agnostic; per-warehouse specifics live in
 each concrete adapter under :mod:`signalforge.warehouse.adapters`.
 
 The :meth:`WarehouseAdapter.from_profile` classmethod is the single
-dispatch point for v0.1: ``profile.type == "bigquery"`` lazy-imports
-:class:`signalforge.warehouse.adapters.bigquery.BigQueryAdapter`; anything
-else raises :class:`signalforge.warehouse.errors.UnsupportedProfileTypeError`.
-The lazy import keeps ``google-cloud-bigquery`` off the import path of
-callers that never invoke ``from_profile`` (e.g. tests injecting a fake
-client directly).
+dispatch point. v0.1 implemented ``profile.type == "bigquery"`` only;
+issue #53 added a ``profile.type == "postgres"`` branch that routes to
+:class:`signalforge.warehouse.adapters.postgres.PostgresAdapter` — a v0.2
+stub whose warehouse-operation methods (``sample_rows`` /
+``column_stats`` / ``run_test_sql``) raise :class:`NotImplementedError`
+naming the ticket. Any other ``profile.type`` raises
+:class:`signalforge.warehouse.errors.UnsupportedProfileTypeError`. The
+lazy imports keep ``google-cloud-bigquery`` (and any future Postgres
+driver) off the import path of callers that never invoke ``from_profile``
+(e.g. tests injecting a fake client directly).
 """
 
 from __future__ import annotations
@@ -171,12 +175,23 @@ class WarehouseAdapter(abc.ABC):
     def from_profile(cls, profile: DbtProfileTarget) -> WarehouseAdapter:
         """Dispatch on ``profile.type`` and instantiate the matching adapter.
 
-        v0.1 supports only ``profile.type == "bigquery"``; anything else
-        raises :class:`UnsupportedProfileTypeError`. Direct instantiation
-        of a concrete adapter remains supported for tests and explicit-config
-        use; this factory is the single dispatch point for the CLI / prune
-        layer so v0.2 can add a Snowflake case in one place rather than
-        threading dispatch through every caller.
+        Supported types:
+
+        * ``"bigquery"`` — returns a fully-implemented
+          :class:`signalforge.warehouse.adapters.bigquery.BigQueryAdapter`.
+        * ``"postgres"`` — returns the v0.2 stub
+          :class:`signalforge.warehouse.adapters.postgres.PostgresAdapter`
+          (issue #53); its warehouse-operation methods raise
+          :class:`NotImplementedError` until the full implementation
+          lands.
+
+        Anything else raises :class:`UnsupportedProfileTypeError`.
+
+        Direct instantiation of a concrete adapter remains supported for
+        tests and explicit-config use; this factory is the single
+        dispatch point for the CLI / prune layer so v0.x can add a
+        Snowflake case in one place rather than threading dispatch
+        through every caller.
         """
         from signalforge.warehouse.errors import UnsupportedProfileTypeError
 
@@ -202,7 +217,8 @@ class WarehouseAdapter(abc.ABC):
         if profile.type == "postgres":
             # v0.2 stub (issue #53) — validates the warehouse-agnostic seam
             # by routing a second profile.type through the factory. The
-            # adapter raises NotImplementedError on every non-dialect call;
+            # adapter's warehouse-operation methods (sample_rows /
+            # column_stats / run_test_sql) raise NotImplementedError;
             # operators see a clear "v0.2 pending" signal rather than the
             # v0.1 UnsupportedProfileTypeError.
             from signalforge.warehouse.adapters.postgres import PostgresAdapter

--- a/src/signalforge/warehouse/base.py
+++ b/src/signalforge/warehouse/base.py
@@ -199,6 +199,18 @@ class WarehouseAdapter(abc.ABC):
                 location=profile.location,
                 max_bytes_billed=max_bytes_billed,
             )
+        if profile.type == "postgres":
+            # v0.2 stub (issue #53) — validates the warehouse-agnostic seam
+            # by routing a second profile.type through the factory. The
+            # adapter raises NotImplementedError on every non-dialect call;
+            # operators see a clear "v0.2 pending" signal rather than the
+            # v0.1 UnsupportedProfileTypeError.
+            from signalforge.warehouse.adapters.postgres import PostgresAdapter
+
+            return PostgresAdapter(
+                dbname=profile.project,
+                schema=profile.dataset,
+            )
         raise UnsupportedProfileTypeError(profile_type=profile.type)
 
 

--- a/src/signalforge/warehouse/models.py
+++ b/src/signalforge/warehouse/models.py
@@ -79,6 +79,29 @@ BIGQUERY_DIALECT = Dialect(
 )
 
 
+POSTGRES_DIALECT = Dialect(
+    name="postgres",
+    supports_tablesample=True,
+    supports_qualify=False,
+    quote_char='"',
+    identifier_case="lower",
+)
+"""Postgres-flavoured :class:`Dialect` for the v0.2 stub adapter (issue #53).
+
+* ``quote_char='"'`` — Postgres uses double-quote for identifier quoting.
+* ``identifier_case='lower'`` — unquoted identifiers are folded to
+  lowercase (matches Postgres's own SQL parser behaviour).
+* ``supports_qualify=False`` — Postgres has no ``QUALIFY`` clause.
+* ``supports_tablesample=True`` — ``TABLESAMPLE`` is supported (BERNOULLI
+  / SYSTEM), though the prune layer prefers deterministic hash-mod
+  sampling anyway (DEC-006 of issue #3).
+
+Lives alongside :data:`BIGQUERY_DIALECT` per DEC-003 so the prune
+compiler (and any other dialect-aware consumer) imports every flavour
+from one place rather than reaching into adapter modules.
+"""
+
+
 # ---------------------------------------------------------------------------
 # TableRef
 # ---------------------------------------------------------------------------
@@ -256,6 +279,7 @@ __all__ = [
     "BIGQUERY_DIALECT",
     "ColumnStats",
     "Dialect",
+    "POSTGRES_DIALECT",
     "PartitionFilter",
     "TableRef",
     "TestResult",

--- a/tests/fixtures/profiles/postgres.yml
+++ b/tests/fixtures/profiles/postgres.yml
@@ -1,0 +1,17 @@
+# Minimal valid Postgres profile for the v0.2 stub adapter (issue #53).
+# Exercises the WarehouseAdapter.from_profile dispatch path for
+# `type: postgres` without depending on a real Postgres connection.
+#
+# Note: the current DbtProfileTarget model is BigQuery-shaped
+# (`extra="forbid"`), so Postgres-specific fields (host/port/user/password)
+# are not present here. A real Postgres adapter (v0.x) will need to relax
+# or split the profile model — that work belongs to the v0.x ticket, not
+# the stub. ``project`` maps to the Postgres dbname and ``schema`` (YAML)
+# maps to ``DbtProfileTarget.dataset``.
+signalforge_test_postgres:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      project: analytics_db
+      schema: public

--- a/tests/warehouse/test_postgres_stub.py
+++ b/tests/warehouse/test_postgres_stub.py
@@ -1,0 +1,169 @@
+"""Tests for the PostgresAdapter v0.2 stub (issue #53).
+
+The stub exists to validate Architectural Commitment #3 — "warehouse-agnostic
+by design" — by forcing the ``WarehouseAdapter`` ABC + ``from_profile``
+factory through a second concrete code path. Tests pin:
+
+* The stub's :meth:`dialect` returns a Postgres-flavoured :class:`Dialect`
+  with the load-bearing flags the prune compiler keys on (``quote_char``,
+  ``identifier_case``, ``supports_qualify``).
+* :meth:`WarehouseAdapter.from_profile` dispatches ``type: postgres`` to
+  the stub.
+* Every non-``dialect`` / non-``__init__`` method raises
+  :class:`NotImplementedError` with a message naming the ticket (#53).
+* A fixture-shaped profile YAML round-trips through :func:`load_profile`
+  and out to a constructed adapter without error — exercises the seam
+  end-to-end without depending on real Postgres credentials.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from signalforge.warehouse.adapters.postgres import POSTGRES_DIALECT, PostgresAdapter
+from signalforge.warehouse.base import WarehouseAdapter
+from signalforge.warehouse.models import Dialect, TableRef
+from signalforge.warehouse.profiles import DbtProfileTarget, load_profile
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "profiles"
+
+
+def _write_dbt_project(project_dir: Path, profile_name: str) -> None:
+    (project_dir / "dbt_project.yml").write_text(
+        f"name: signalforge_test\nversion: '1.0.0'\nconfig-version: 2\nprofile: {profile_name}\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dialect contract
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_dialect_values() -> None:
+    """The Postgres :class:`Dialect` must carry the values the prune
+    compiler keys on (``prune-engine.md`` DEC-025). Drift on any of
+    these would change the compiled SQL bytes silently."""
+    assert isinstance(POSTGRES_DIALECT, Dialect)
+    assert POSTGRES_DIALECT.name == "postgres"
+    assert POSTGRES_DIALECT.quote_char == '"'
+    assert POSTGRES_DIALECT.identifier_case == "lower"
+    assert POSTGRES_DIALECT.supports_qualify is False
+
+
+def test_dialect_method_returns_postgres_dialect() -> None:
+    """:meth:`PostgresAdapter.dialect` must return the module-level
+    constant, not a freshly-constructed equivalent — callers may key on
+    identity for cheap dispatch."""
+    adapter = PostgresAdapter()
+    assert adapter.dialect() is POSTGRES_DIALECT
+
+
+# ---------------------------------------------------------------------------
+# Stub methods raise NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_sample_rows_raises_not_implemented() -> None:
+    """The v0.2 stub raises :class:`NotImplementedError` on
+    :meth:`sample_rows` and names the ticket so the v0.2 implementation
+    work has a single grep target."""
+    adapter = PostgresAdapter()
+    table = TableRef(project=None, dataset="public", name="t")
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        adapter.sample_rows(table, 100)
+
+    assert "issue #53" in str(exc_info.value)
+
+
+def test_column_stats_raises_not_implemented() -> None:
+    """:meth:`column_stats` is part of the v0.2 stub surface."""
+    adapter = PostgresAdapter()
+    table = TableRef(project=None, dataset="public", name="t")
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        adapter.column_stats(table, "id")
+
+    assert "issue #53" in str(exc_info.value)
+
+
+def test_run_test_sql_raises_not_implemented() -> None:
+    """:meth:`run_test_sql` is part of the v0.2 stub surface."""
+    adapter = PostgresAdapter()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        adapter.run_test_sql("SELECT 1")
+
+    assert "issue #53" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# from_profile dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_from_profile_dispatches_postgres_to_stub() -> None:
+    """The factory must route ``type: postgres`` to the stub adapter
+    (NOT raise :class:`UnsupportedProfileTypeError`). Operator-facing
+    signal: ``NotImplementedError("…issue #53…")`` instead of "type not
+    supported in v0.1"."""
+    profile = DbtProfileTarget.model_validate(
+        {
+            "type": "postgres",
+            "project": "analytics_db",
+            "schema": "public",
+        }
+    )
+
+    adapter = WarehouseAdapter.from_profile(profile)
+
+    assert isinstance(adapter, PostgresAdapter)
+    assert adapter._dbname == "analytics_db"
+    assert adapter._schema == "public"
+
+
+def test_from_profile_postgres_loads_from_fixture_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a Postgres ``profiles.yml`` round-trips through
+    :func:`load_profile` and :meth:`WarehouseAdapter.from_profile` to a
+    constructed stub adapter without error. Pins the seam across YAML
+    parse, ``DbtProfileTarget`` validation, and factory dispatch."""
+    monkeypatch.delenv("DBT_PROFILES_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "fake_home")
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_dbt_project(project_dir, profile_name="signalforge_test_postgres")
+    shutil.copy(FIXTURES / "postgres.yml", project_dir / "profiles.yml")
+
+    target = load_profile(project_dir)
+
+    assert target.type == "postgres"
+    assert target.project == "analytics_db"
+    assert target.dataset == "public"
+
+    adapter = WarehouseAdapter.from_profile(target)
+    assert isinstance(adapter, PostgresAdapter)
+    assert adapter._dbname == "analytics_db"
+    assert adapter._schema == "public"
+
+
+# ---------------------------------------------------------------------------
+# Context-manager parity with the BigQuery adapter
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_is_a_no_op() -> None:
+    """The stub honours the ABC's ``with adapter:`` contract (DEC-013 of
+    issue #22 generalised) so callers can swap a Postgres profile in for
+    a BigQuery one without conditional ``with`` logic. The stub's
+    ``__exit__`` is a no-op; cleanup work lands when the v0.x
+    implementation does."""
+    with PostgresAdapter() as adapter:
+        assert isinstance(adapter, PostgresAdapter)
+        assert adapter.dialect() is POSTGRES_DIALECT

--- a/tests/warehouse/test_postgres_stub.py
+++ b/tests/warehouse/test_postgres_stub.py
@@ -9,8 +9,11 @@ factory through a second concrete code path. Tests pin:
   ``identifier_case``, ``supports_qualify``).
 * :meth:`WarehouseAdapter.from_profile` dispatches ``type: postgres`` to
   the stub.
-* Every non-``dialect`` / non-``__init__`` method raises
-  :class:`NotImplementedError` with a message naming the ticket (#53).
+* The three warehouse-operation methods (``sample_rows`` /
+  ``column_stats`` / ``run_test_sql``) raise :class:`NotImplementedError`
+  with a message naming the ticket (#53). ``__enter__`` / ``__exit__``
+  are intentionally implemented as no-ops so the ``with adapter:``
+  contract works without conditional logic at the call site.
 * A fixture-shaped profile YAML round-trips through :func:`load_profile`
   and out to a constructed adapter without error — exercises the seam
   end-to-end without depending on real Postgres credentials.
@@ -23,9 +26,9 @@ from pathlib import Path
 
 import pytest
 
-from signalforge.warehouse.adapters.postgres import POSTGRES_DIALECT, PostgresAdapter
+from signalforge.warehouse.adapters.postgres import PostgresAdapter
 from signalforge.warehouse.base import WarehouseAdapter
-from signalforge.warehouse.models import Dialect, TableRef
+from signalforge.warehouse.models import POSTGRES_DIALECT, Dialect, TableRef
 from signalforge.warehouse.profiles import DbtProfileTarget, load_profile
 
 FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "profiles"


### PR DESCRIPTION
## Summary

- Adds `src/signalforge/warehouse/adapters/postgres.py` — `PostgresAdapter` stub implementing `__init__` (captures connection params) and `dialect()` (returns Postgres-flavoured `Dialect`: `quote_char='"'`, `identifier_case='lower'`, `supports_qualify=False`). Every other abstract method raises `NotImplementedError` naming this ticket.
- Wires `WarehouseAdapter.from_profile` for `profile.type == "postgres"` so an operator with a Postgres profile sees `NotImplementedError("…issue #53…")` rather than the v0.1 `UnsupportedProfileTypeError`.
- Adds `tests/fixtures/profiles/postgres.yml` + `tests/warehouse/test_postgres_stub.py` (8 tests: dialect values, dispatch path, fixture-yaml round-trip, every `NotImplementedError` surface, context-manager parity).
- Adds a note to `.claude/rules/warehouse-adapters.md` documenting the second-adapter stub.

Validates Architectural Commitment #3 ("warehouse-agnostic by design"). Pre-#53 the only concrete adapter was `bigquery.py`; the ABC + `Dialect` seam was unverified by a second adapter. Forces the seam through a second code path right now so a v0.2 leak surfaces here instead of during real Postgres / Snowflake implementation. Closes #53.

## Test plan

- [x] `ruff check . && ruff format --check .`
- [x] `pyright` (0 errors, 0 warnings)
- [x] `pytest tests/warehouse/test_postgres_stub.py tests/warehouse/test_base.py tests/warehouse/test_profiles.py` — 33 passed
- [x] Full `pytest` — 1752 passed, 1 skipped, 6 pre-existing WSL2 symlink-loop failures (unrelated; pass in GHA)
- [x] Coverage: 95.95% overall, 97% on new `postgres.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Postgres warehouse adapter supporting dbt Postgres profiles. Connection parameters include host, port, database name, schema, and authentication credentials. The profile factory now automatically routes Postgres profiles to this adapter.

* **Tests**
  * Added full test coverage for Postgres adapter initialization, configuration, dialect behavior, and factory integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->