### PR TITLE
57: trigger CI on release/* branches

### DIFF
--- a/.claude/rules/ci-supply-chain.md
+++ b/.claude/rules/ci-supply-chain.md
@@ -40,6 +40,12 @@ Saves runner minutes and surfaces the latest result faster.
 
 DEC-003: lock to one Python version (currently `3.11`) for v0.1 CI. Widen the matrix when the package has real users running on multiple versions.
 
+## CI triggers cover every long-lived branch
+
+Established by issue #57. `on.push.branches` includes `main`, `dev`, AND `release/*`. Release-prep commits (tag-prep, release-note fixes, hotfix backports) land directly on a `release/*` branch and must get CI feedback. Without the `release/*` glob, a direct push to a release branch bypasses CI entirely; PRs targeting `main` still trigger via the `pull_request` branch list, but ad-hoc commits on the release branch do not.
+
+When a new long-lived branch shape lands (e.g., `hotfix/*` in v0.3), add it to BOTH `on.push.branches` AND `on.pull_request.branches` in lockstep. Short-lived feature branches don't need triggers — PRs targeting `main` / `dev` already cover them.
+
 ## Codecov coverage upload
 
 Established by issue #27 (DEC-006, DEC-007). The upload step follows the same SHA-pinning rule as other third-party actions:
@@ -64,4 +70,4 @@ The step must land AFTER the pytest step. `coverage.xml` is produced by `--cov-r
 
 ## Reference
 
-`plans/super/1-project-scaffolding.md` — DEC-003, DEC-009. `plans/super/27-codecov-coverage.md` — DEC-006, DEC-007. `.github/workflows/ci.yml` — current implementation.
+`plans/super/1-project-scaffolding.md` — DEC-003, DEC-009. `plans/super/27-codecov-coverage.md` — DEC-006, DEC-007. Issue #57 — `release/*` push trigger. `.github/workflows/ci.yml` — current implementation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, "release/*"]
   push:
     branches: [main, dev, "release/*"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, dev]
   push:
-    branches: [main, dev]
+    branches: [main, dev, "release/*"]
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #57.

## Summary
- Add `release/*` to `on.push.branches` in `.github/workflows/ci.yml` so release-prep commits get CI feedback (option A from the issue).
- Document the trigger contract in `.claude/rules/ci-supply-chain.md` and extend the future-shape guidance to cover `hotfix/*` in v0.3.

## Test plan
- [ ] CI runs on this PR (via `pull_request: dev`).
- [ ] After merge, push a no-op commit to a `release/0.1.0`-shaped branch and confirm CI fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflows now automatically trigger on release-preparation branches, ensuring release-related commits receive automated testing and validation alongside main and dev branch activity.

* **Documentation**
  * Updated CI guidelines to define triggering conventions for comprehensive workflow coverage across long-lived branch patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->