### PR TITLE
chore: bump to 0.1.0rc2 for test release

### DIFF
--- a/src/signalforge/__init__.py
+++ b/src/signalforge/__init__.py
@@ -1,3 +1,3 @@
 """SignalForge: LLM-drafted, warehouse-pruned dbt artifacts."""
 
-__version__ = "0.1.0rc1"
+__version__ = "0.1.0rc2"


### PR DESCRIPTION
Version bump for the 0.1.0rc2 TestPyPI test release. Tags `main` HEAD after merge.

Pre-flight passed:
- ruff check / format / pyright: PASS
- pytest: 1822 passed, 1 skipped, 6 known WSL2-local symlink-loop failures (pass in GHA)
- `python -m build` + `uvx twine check`: PASSED on wheel and sdist
- 0.1.0rc2 not on TestPyPI yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.1.0rc2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->