### PR TITLE
93: silence pydantic UserWarning for LLMRequest.schema field shadow

### DIFF
--- a/.claude/rules/safety-layer.md
+++ b/.claude/rules/safety-layer.md
@@ -91,6 +91,20 @@ Same rule as the other layers (`llm-drafter.md` DEC-011 / `prune-engine.md` DEC-
 
 If you add a new module that genuinely needs to construct an `LLMRequest` (e.g., a deserialiser for resumption), update the exclusion list AND document the audit-write seam. Don't suppress the test.
 
+## Pydantic field-name shadow of `BaseModel` — scope the suppression, don't rename (issue #93)
+
+`LLMRequest.schema: tuple[tuple[str, str], ...]` deliberately shadows Pydantic v1's deprecated `BaseModel.schema()` method. The field name is part of the audit-log contract (DEC-014); renaming would break `safety.jsonl` consumers, and a Pydantic `Field(alias="schema")` would change the Python attribute name out from under every internal caller of `request.schema`.
+
+Pydantic emits a `UserWarning` at class-creation time for this kind of shadow. The fix is `warnings.catch_warnings()` around the class definition with a targeted `filterwarnings("ignore", message=r'Field name "schema".*shadows.*', category=UserWarning)`. Three rules:
+
+1. **Scope to the class definition, not the module / process.** A bare `warnings.filterwarnings(...)` at module top-level permanently mutates the global filter list and silences unrelated future warnings. `catch_warnings()` is a context manager that restores the prior filter state on exit.
+2. **Pin the message regex.** A category-only filter (`category=UserWarning`) is too broad. The `message=r'...'` anchor catches the specific Pydantic shadow warning and nothing else.
+3. **Keep the existing `pyright: ignore[reportIncompatibleMethodOverride]` on the field.** Pyright's structural-override complaint is a separate signal from Pydantic's runtime UserWarning; both need their own suppression.
+
+Regression test: `tests/safety/test_models.py::test_importing_safety_models_emits_no_userwarning` shells out a subprocess with `-W error::UserWarning` and asserts exit 0. Subprocess (not in-process `importlib.reload`) because the parent process imports `signalforge.safety.models` via the test collector before any in-test code runs.
+
+When a future Pydantic field-name shadow surfaces (an audit-log contract is the same kind of "renaming would break consumers" pin), match this shape verbatim — don't reach for a global filter, and don't rename the field.
+
 ## Fail-closed writer shape — Scan 8 covers all five writers (issue #38)
 
 `tests/test_audit_completeness.py::test_fail_closed_writers_have_no_except_around_write_fsync` and `test_fail_closed_writers_use_short_write_loop` are the eighth AST scan in the project. They walk every fail-closed writer module — `signalforge.{safety,draft,prune,grade}.audit` and `signalforge.diff._sidecar` — and assert: (a) no `except` handler may wrap a `Try` whose body issues `os.write` / `os.fsync` (only `try / finally` around `os.close(fd)` is permitted); (b) every writer function uses a `while` loop around `os.write` so short writes (`EINTR`, pathological short returns) don't produce partial JSONL records.

--- a/src/signalforge/safety/models.py
+++ b/src/signalforge/safety/models.py
@@ -33,6 +33,7 @@ Design commitments operationalised here:
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Literal
@@ -141,41 +142,54 @@ class AuditEvent(BaseModel):
         return iso8601_z(value)
 
 
-class LLMRequest(BaseModel):
-    """The request payload handed to issue #5's LLM-drafting layer.
-
-    Construct only via :func:`signalforge.safety.request.build_llm_request` —
-    direct construction bypasses the audit log and breaks the reproducibility
-    contract documented in DEC-014. The AST scan in US-011 enforces this
-    convention at lint time; this docstring is the human-readable companion.
-
-    Sequences are :class:`tuple` (DEC-022) so the request cannot be mutated
-    after the audit event has been written.
-    """
-
-    model_config = ConfigDict(
-        frozen=True,
-        extra="ignore",
-        populate_by_name=True,
-        arbitrary_types_allowed=True,
+# The ``schema`` field name shadows Pydantic v1's deprecated
+# :meth:`BaseModel.schema` method, which makes Pydantic emit a UserWarning at
+# class-creation time. The field name is part of the documented LLMRequest
+# contract (audit-log shape per safety-layer.md DEC-014), so the override is
+# intentional. Scope the suppression to this one class definition rather than
+# mutating the global filter list — issue #93.
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message=r'Field name "schema" in "LLMRequest" shadows an attribute in parent "BaseModel"',
+        category=UserWarning,
     )
 
-    model_unique_id: str
-    mode: SamplingMode
-    columns_sent: tuple[str, ...]
-    redactions: tuple[RedactionRecord, ...]
-    sampled_rows: tuple[dict[str, Any], ...] | None = None
-    # Tuple-of-tuples (not dict) so frozen=True actually prevents mutation:
-    # downstream consumers cannot do `request.aggregates["x"] = ...` post-audit
-    # (DEC-022 transitive immutability). Convention: list order matches
-    # ``columns_sent``; redacted columns appear with their hashed name as key
-    # and ``None`` as value.
-    aggregates: tuple[tuple[str, ColumnStats | None], ...] | None = None
-    # ``schema`` overrides Pydantic v1's deprecated :meth:`BaseModel.schema`
-    # method on this subclass. The override is intentional — the field name is
-    # part of the documented LLMRequest contract — so pyright's structural
-    # complaint is silenced here rather than renamed.
-    schema: tuple[tuple[str, str], ...]  # pyright: ignore[reportIncompatibleMethodOverride]
+    class LLMRequest(BaseModel):
+        """The request payload handed to issue #5's LLM-drafting layer.
+
+        Construct only via :func:`signalforge.safety.request.build_llm_request` —
+        direct construction bypasses the audit log and breaks the reproducibility
+        contract documented in DEC-014. The AST scan in US-011 enforces this
+        convention at lint time; this docstring is the human-readable companion.
+
+        Sequences are :class:`tuple` (DEC-022) so the request cannot be mutated
+        after the audit event has been written.
+        """
+
+        model_config = ConfigDict(
+            frozen=True,
+            extra="ignore",
+            populate_by_name=True,
+            arbitrary_types_allowed=True,
+        )
+
+        model_unique_id: str
+        mode: SamplingMode
+        columns_sent: tuple[str, ...]
+        redactions: tuple[RedactionRecord, ...]
+        sampled_rows: tuple[dict[str, Any], ...] | None = None
+        # Tuple-of-tuples (not dict) so frozen=True actually prevents mutation:
+        # downstream consumers cannot do `request.aggregates["x"] = ...` post-audit
+        # (DEC-022 transitive immutability). Convention: list order matches
+        # ``columns_sent``; redacted columns appear with their hashed name as key
+        # and ``None`` as value.
+        aggregates: tuple[tuple[str, ColumnStats | None], ...] | None = None
+        # ``schema`` overrides Pydantic v1's deprecated :meth:`BaseModel.schema`
+        # method on this subclass; the structural override is silenced for
+        # pyright here and the runtime UserWarning is silenced by the
+        # ``catch_warnings`` block above.
+        schema: tuple[tuple[str, str], ...]  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 __all__ = [

--- a/src/signalforge/safety/models.py
+++ b/src/signalforge/safety/models.py
@@ -149,9 +149,14 @@ class AuditEvent(BaseModel):
 # intentional. Scope the suppression to this one class definition rather than
 # mutating the global filter list — issue #93.
 with warnings.catch_warnings():
+    # Relaxed regex (not the literal full message) so a future Pydantic
+    # version rewording the suffix still gets caught. Scoped to a narrow
+    # message anchor + ``UserWarning`` category — broad enough to survive
+    # message-wording drift, narrow enough not to swallow unrelated
+    # warnings.
     warnings.filterwarnings(
         "ignore",
-        message=r'Field name "schema" in "LLMRequest" shadows an attribute in parent "BaseModel"',
+        message=r'Field name "schema".*shadows.*',
         category=UserWarning,
     )
 

--- a/tests/safety/test_models.py
+++ b/tests/safety/test_models.py
@@ -13,6 +13,8 @@ file only validates the production shapes' behaviour.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -264,6 +266,22 @@ def test_llm_request_docstring_warns_about_direct_construction() -> None:
 # ---------------------------------------------------------------------------
 # Module surface
 # ---------------------------------------------------------------------------
+
+
+def test_importing_safety_models_emits_no_userwarning() -> None:
+    """Issue #93: a clean import must not emit the Pydantic ``schema``-shadow
+    UserWarning. Run in a subprocess so the import is genuinely fresh — the
+    parent process already imported the module via the test collector."""
+    result = subprocess.run(
+        [sys.executable, "-W", "error::UserWarning", "-c", "import signalforge.safety.models"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"importing signalforge.safety.models surfaced a UserWarning:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
 
 
 def test_module_all_lists_documented_classes() -> None:

--- a/tests/safety/test_models.py
+++ b/tests/safety/test_models.py
@@ -277,6 +277,7 @@ def test_importing_safety_models_emits_no_userwarning() -> None:
         capture_output=True,
         text=True,
         check=False,
+        timeout=10,
     )
     assert result.returncode == 0, (
         f"importing signalforge.safety.models surfaced a UserWarning:\n"


### PR DESCRIPTION
## Summary

- Closes #93. `LLMRequest.schema` is a deliberate field name (audit-log contract per safety-layer.md DEC-014), but it shadows Pydantic v1's deprecated `BaseModel.schema` method — Pydantic emits a `UserWarning` at class-creation time that surfaces on every fresh import / `signalforge --version` invocation.
- Pick option 1 from the issue: wrap the `LLMRequest` class definition in `warnings.catch_warnings()` with a `filterwarnings("ignore", message=r'Field name "schema".*shadows.*', category=UserWarning)`. Narrowest blast radius; scoped to one class definition, no global filter mutation. Public contract and `safety.jsonl` shape unchanged.
- Add a subprocess-import regression test under `-W error::UserWarning` so a future shape change can't silently reintroduce the warning. Subprocess (not in-process `importlib.reload`) because the parent process already imported the module via the test collector.

## Test plan

- [x] `pytest tests/safety/ --no-cov` — 262 passed (including the new `test_importing_safety_models_emits_no_userwarning`).
- [x] `ruff check` + `ruff format --check` + `pyright` — clean on both touched files.
- [x] Manual repro: `python -W error::UserWarning -c "import signalforge.safety.models; from signalforge.cli import main; main(['--version'])"` exits 0, prints `signalforge 0.1.0rc2`.
- [x] Default `pytest --no-cov` — 1823 passed; 6 pre-existing WSL2 symlink-loop failures (orthogonal to this change, pass on the GHA Linux runner).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to ensure clean module imports without warnings.

* **Chores**
  * Improved internal warning handling for better code stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->