### PR TITLE
chore: release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to SignalForge are documented here. The format is loosely ba
 
 _Nothing yet — entries land here on `dev` and get promoted to a dated section at release time._
 
-## [0.1.0] — 2026-05-11
+## [0.1.0] — 2026-05-20
 
 First public release. Single-model draft + warehouse prune + LLM-as-judge grade + diff renderer, BigQuery only, CLI surface.
 

--- a/src/signalforge/__init__.py
+++ b/src/signalforge/__init__.py
@@ -1,3 +1,3 @@
 """SignalForge: LLM-drafted, warehouse-pruned dbt artifacts."""
 
-__version__ = "0.1.0rc3"
+__version__ = "0.1.0"


### PR DESCRIPTION
Cuts **v0.1.0** to PyPI — the first production publish of `signalforge-dbt`.

## Changes
- `src/signalforge/__init__.py`: `0.1.0rc3` → `0.1.0`
- `CHANGELOG.md`: `[0.1.0]` section re-dated `2026-05-11` → `2026-05-20` (actual PyPI ship date). Section content unchanged — it already documents the full v0.1 surface (#2–#11, #27).

## Pre-flight
- Branch `main`, clean tree, in sync with origin
- `uv run ruff check .` / `ruff format --check .` / `pyright` — all clean
- `uv run --python 3.12 pytest` — 1830 passed
- `uv build` + `uvx twine check` — **PASSED** on wheel and sdist
- `0.1.0` free on PyPI (first publish)

## After merge
Tag `v0.1.0` on the merge commit → non-prerelease GitHub Release (body = the `[0.1.0]` CHANGELOG section) → `publish-pypi` job → https://pypi.org/project/signalforge-dbt/0.1.0/

> Note: the branch is `release/0.1.0-cut` (not `release/0.1.0`) because a stale `release/0.1.0` branch from issue #12's dry-run still exists on the remote — left untouched; worth deleting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.0
  * Updated release date in changelog

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->