### PR TITLE
chore: begin 0.2.0.dev0

### DIFF
--- a/src/signalforge/__init__.py
+++ b/src/signalforge/__init__.py
@@ -1,3 +1,3 @@
 """SignalForge: LLM-drafted, warehouse-pruned dbt artifacts."""
 
-__version__ = "0.1.0rc3"
+__version__ = "0.2.0.dev0"


### PR DESCRIPTION
Bumps version to `0.2.0.dev0` after the v0.1.0 release (now live on PyPI: https://pypi.org/project/signalforge-dbt/0.1.0/).