### PR TITLE
docs: README install instructions for the live PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ SignalForge generates the same artifacts, then asks a different question: **does
 
 The grading layer reuses [clauditor](https://github.com/wjduenow/clauditor)'s LLM-as-judge methodology, applied to a new artifact class.
 
-> **Status (v0.1):** Not yet on PyPI. Today the package installs from a
-> clone with `uv sync --dev` (or `pip install -e ".[dev]"` for contributors
-> without uv).
+> **Status (v0.1):** Live on PyPI — `pip install signalforge-dbt`. See [Quick start](#quick-start).
 
 ## Quick start
 
@@ -56,18 +54,28 @@ is roughly 5–6 minutes.
 
 ### 1. Install
 
-SignalForge requires **Python 3.11+**. It is not yet published on PyPI — install from a clone:
+SignalForge requires **Python 3.11+**.
 
 ```bash
-git clone https://github.com/wjduenow/SignalForge.git
-cd SignalForge
-uv sync --dev   # or: pip install -e ".[dev]"  (back-compat for non-uv setups)
+pip install signalforge-dbt
 ```
 
-Once v0.1 ships to PyPI, `pip install signalforge-dbt` will replace the
-editable-install step. (The PyPI name has a `-dbt` suffix because
-`signalforge` was already taken by an unrelated DSP package; the import
-name and CLI command remain `signalforge`.)
+Verify the CLI is on your PATH:
+
+```bash
+signalforge --version
+```
+
+The PyPI distribution name is **`signalforge-dbt`** (the bare `signalforge` name
+is held by an unrelated DSP package); the import package and CLI command are both
+**`signalforge`**.
+
+**Prefer an isolated CLI install?** `uv tool install signalforge-dbt` (or
+`pipx install signalforge-dbt`) puts the `signalforge` command on your PATH
+without adding it to a project environment.
+
+**Working from a clone (contributing)?** Install the dev toolchain with
+`uv sync --dev` — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
 ### 2. Authenticate to BigQuery and Anthropic
 


### PR DESCRIPTION
Fast-tracks the README install section to `main` now that `signalforge-dbt 0.1.0` is live on PyPI (https://pypi.org/project/signalforge-dbt/0.1.0/), so the PyPI long-description and the published docs site stop saying "not yet on PyPI."

Cherry-pick of the README-only commit from dev (`fde274e`) — **README.md only**, no version bump (main stays at `0.1.0`; dev carries `0.2.0.dev0`).

## Changes
- Status line: "Not yet on PyPI" → "Live on PyPI — `pip install signalforge-dbt`".
- Quick start §1: leads with `pip install signalforge-dbt` + `signalforge --version` verify; clarifies `signalforge-dbt` distribution name vs `signalforge` import/CLI; adds `uv tool install` / `pipx` isolated-CLI option; demotes the clone + `uv sync --dev` path to a CONTRIBUTING.md pointer.

## After merge
The push to `main` redeploys the docs site (the `docs:` job) with the corrected install copy, and the next `signalforge-dbt` upload's long-description will match. The README content is already on `dev` too (`fde274e`), so no backmerge is needed for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * v0.1 is now available on PyPI with updated installation guidance
  * Streamlined quick-start setup process for easier package installation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wjduenow/SignalForge/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->