### PR TITLE
docs: steer pre-release gated-marker runs to the matrix ceiling (3.13)

### DIFF
--- a/.claude/rules/testing-signal.md
+++ b/.claude/rules/testing-signal.md
@@ -108,6 +108,8 @@ SF_RUN_BQ=1 GOOGLE_CLOUD_PROJECT=<billing-project> ANTHROPIC_API_KEY=sk-... pyte
 
 For a one-shot **pre-release** measurement of how much coverage the gated paths contribute (run all gated markers under `--cov` in a single invocation), see `CONTRIBUTING.md` § "Pre-release coverage audit". A maintainer running that before each release catches coverage regressions in the gated paths that the default badge number cannot surface.
 
+The gated markers carry **no Python-version pin** — they run on whatever interpreter `uv run` resolves, and CI runs none of them (all are deselected by `addopts`). For maintainer runs that exercise the wheel-build (`wheel_smoke`) or console-script (`cli_subprocess`) paths, target the **matrix ceiling** (currently 3.13, issue #96) via `uv run --python 3.13 pytest -m <marker> --no-cov` so packaging/entry-point behaviour is checked on the newest supported interpreter. The live-service markers (`bigquery` / `anthropic` / `e2e`) are interpreter-invariant — run them on a single version; don't multiply paid API calls across the matrix.
+
 The `wheel_smoke` marker (issue #47) verifies wheel-build packaging without coupling it to default CI — the test shells out `python -m build --wheel` and asserts the canonical demo file set appears under `signalforge/_demo/`. See `python-build.md` § "Shipping package data".
 
 ## End-to-end gated tests (issue #10)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ default marker set. Tests gated behind `bigquery`, `anthropic`, `cli_subprocess`
 `.claude/rules/testing-signal.md` § "Known gap: excluded markers"), so the
 real-network and packaging paths are not instrumented in the badge number.
 
+Run this audit against the **matrix ceiling** (currently Python 3.13 — the
+highest version CI exercises) by prefixing `uv run --python 3.13`, so the
+gated wheel-build (`wheel_smoke`) and console-script (`cli_subprocess`) paths
+are checked on the newest supported interpreter. The gated markers carry no
+version pin; they run on whatever interpreter `uv run` resolves.
+
 Before cutting a release, run both suites and combine their coverage into one
 total to catch regressions in the gated paths:
 


### PR DESCRIPTION
Follow-up to #96 (which made 3.13 the CI matrix ceiling).

## Context
The gated markers — `bigquery`, `anthropic`, `cli_subprocess`, `e2e`, `wheel_smoke` — are **not matrix entries**. No CI job runs them; they're deselected by `addopts` and run manually by a maintainer via `uv run pytest -m <marker> --no-cov`. They carry **no Python-version pin** and run on whatever interpreter `uv run` resolves. So there was nothing to "re-add 3.13 to" in code — only a doc nuance to fix.

## Change (doc-only)
- **`CONTRIBUTING.md` § Pre-release coverage audit** — run the audit against the matrix ceiling (3.13) via `uv run --python 3.13`, so the wheel-build + console-script paths are exercised on the newest supported interpreter.
- **`.claude/rules/testing-signal.md` § Known gap** — same guidance, plus the rationale: `wheel_smoke` / `cli_subprocess` benefit from the ceiling (packaging / entry-point behaviour); the live-service markers (`bigquery` / `anthropic` / `e2e`) are interpreter-invariant and stay single-version to avoid multiplying paid API calls across the matrix.

No code or tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)