### PR TITLE
docs: promote Claude Code skill into the README overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to SignalForge are documented here. The format is loosely ba
 
 ## [Unreleased]
 
-_Nothing yet — entries land here on `dev` and get promoted to a dated section at release time._
+### Docs
+
+- **README overview promotes the Claude Code skill.** Adds a "Drives end-to-end from Claude Code" bullet to § What it does and a new top-level § Claude Code section (between § How it works and § Supported warehouses) with the `signalforge install-skill` command, three example prompts, and a pointer to [docs/skills.md](docs/skills.md) as the deep dive. The pre-existing Quick-start install hint stays as a cross-link reminder rather than the first mention. v0.5.0 shipped the skill itself; this surfaces it where prospective users decide whether SignalForge is for them.
 
 ## [0.5.0] — 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ And you don't have to start from SignalForge's own drafts. Point it at a `schema
 - **Generates documentation** — column-level descriptions and model-level overviews — graded by an LLM-as-judge against a configurable rubric.
 - **Reports what was kept and what was dropped**, with a one-line "why" per artifact. No black-box generation.
 - **Prunes tests you already have.** Point it at an existing `schema.yml` — from dbt-codegen, dbt Copilot, DinoAI, datapilot, or hand-written — and the warehouse tells you which of *those* tests add no signal. Same prune step, no LLM call (`signalforge prune-existing`).
+- **Drives end-to-end from Claude Code.** Run `signalforge install-skill` once in your dbt project and Claude recognises requests like "draft tests for `dim_customers`" or "prune my existing `schema.yml`," picks the right subcommand + flags, and explains the kept / kept-uncertain / dropped / flagged diff back. Deep dive: [Claude Code skill](docs/skills.md).
 
 ## How it works
 
@@ -50,6 +51,24 @@ There's a second entry point that skips the LLM entirely. If you already have a 
 ```
 
 No draft, no grade, no LLM call — just "which of these tests earn their place?" Tests SignalForge can't evaluate (custom / dbt-expectations / namespaced generics) are reported as skipped, never silently dropped.
+
+## Claude Code
+
+SignalForge ships a bundled [Claude Code](https://docs.claude.com/en/docs/claude-code) skill so Claude can drive the `signalforge` CLI end-to-end against your dbt project. Install it once from your project root:
+
+```bash
+signalforge install-skill
+```
+
+This drops the skill into `<project>/.claude/skills/signalforge/`. With it in place, a Claude Code session opened against the project recognises requests in plain English:
+
+- "Draft tests for `dim_customers` and explain what got dropped."
+- "Prune the `schema.yml` I already have at `models/staging/schema.yml`."
+- "Run the demo so I can see what SignalForge actually does."
+
+Claude picks the right subcommand and flags (`generate --write` vs `prune-existing --schema` vs `init-demo` vs `lint`), runs the pipeline, and explains the kept / kept-uncertain / dropped / flagged diff back to you — including the per-artifact "why" for each decision. The skill is shipped inside the `signalforge-dbt` wheel and stays in lockstep with the live CLI via a parity test, so a future subcommand or flag change updates the skill in the same commit.
+
+Full reference: [Claude Code skill](docs/skills.md) — covers the install path and overwrite policy, the 7-step workflow the skill teaches, the zero-credential demo and gated live-e2e flows, the parity gate, and the optional clauditor self-grade.
 
 ## Supported warehouses
 
@@ -113,9 +132,9 @@ without adding it to a project environment.
 **Working from a clone (contributing)?** Install the dev toolchain with
 `uv sync --dev` — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
-Run `signalforge install-skill` to drop the [Claude Code skill](docs/skills.md)
-into your project's `.claude/skills/signalforge/` and let Claude drive
-SignalForge end-to-end.
+**Driving SignalForge from Claude Code?** Per [§ Claude Code](#claude-code)
+above, run `signalforge install-skill` from your dbt project root to drop the
+bundled skill into `.claude/skills/signalforge/`.
 
 ### 2. Authenticate to BigQuery and your LLM provider
 


### PR DESCRIPTION
Surfaces the v0.5.0 \`install-skill\` feature where prospective users decide whether SignalForge is for them. Today the skill is only mentioned once, inside Step 1 of Quick start — easy to miss when skimming for "is this for me?"

**Three edits to README.md:**

1. **New bullet in § What it does** (8th entry in the feature list) — "Drives end-to-end from Claude Code." Links to \`docs/skills.md\` as the deep dive.

2. **New top-level § Claude Code section** between § How it works and § Supported warehouses. Gives the install command, three example prompts ("draft tests for \`dim_customers\`", "prune my \`schema.yml\`", "run the demo"), an explanation of what Claude actually does (picks subcommand + flags, runs the pipeline, explains the kept / kept-uncertain / dropped / flagged diff), and a pointer to \`docs/skills.md\` for the full reference.

3. **Tightens the pre-existing Quick-start install hint** to cross-link to the new § Claude Code section rather than be the first introduction. Avoids redundancy without losing the install-moment reminder.

**One edit to CHANGELOG.md:** new \`[Unreleased]\` § Docs bullet recording the overview promotion. The v0.5.0 entry already documents the feature itself.

**No changes needed elsewhere:**
- \`docs/skills.md\` (the deep dive) already covers everything the new README section points to — install path, 7-step workflow, demo flows, parity gate, clauditor self-grade
- \`mkdocs.yml\` nav already has \`Claude Code Skill: skills.md\` from v0.5.0

**Validation:** \`uv run --only-group docs mkdocs build\` passes — all warnings pre-existing per \`.claude/rules/docs-publishing.md\` (repo-internal \`plans/super/\` links deliberately not in the site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added dedicated "Claude Code" section to README with installation instructions, example prompts, and usage guidelines
  * Updated "What it does" section with Claude Code integration reference
  * Reorganized Quick Start flow to guide users through Claude Code setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->