### PR TITLE
#179: empirical retest writeup against intuit_airflow

### DIFF
--- a/docs/research/179-test-primitive-expansion-retest.md
+++ b/docs/research/179-test-primitive-expansion-retest.md
@@ -1,0 +1,404 @@
+# Issue #179 — empirical retest against `intuit_airflow`
+
+**Status:** retest complete on 2026-06-01. Phase A (single-model binary check)
+and Phase B (15-model aggregate) ran; Phase C (#171 calibration) deferred —
+requires a maintainer-controlled Snowflake fixture warehouse per the epic's
+option 3 and the operator does not have one.
+
+**Anchor commits on `dev`:** `7cc4e80 #171: row_count_anomaly_by_period`,
+`42eae99 #170: unique_combination`, `2fdb91e #169: row_count_between`.
+SignalForge `0.6.0.dev0` (editable install in `~/Projects/intuit_airflow/.venv-dbt`).
+
+## tl;dr
+
+- **#170 `unique_combination`** ships well-calibrated. 100% binary match-rate
+  on a 5-model sample; 80% exact column-set match. **Beats the epic's
+  projection (+14 pp above the 86% target).**
+- **#169 `row_count_between`** under-delivers on this fixture. 57.1% match-rate
+  on a 14-model sample. **Misses the epic's projected 76% by 18.9 pp, well
+  outside the ±5 pp acceptance window.** A specific named cause (missing
+  scope-instruction in the cached system prompt) accounts for some of the gap;
+  a secondary clustering hypothesis (drafter prioritises composite-uniqueness
+  when both shapes apply) accounts for more. Filed as a tracked follow-on.
+- **#171 `row_count_anomaly_by_period`** has a drafter-calibration bug visible
+  on every Phase B model: when the manifest carries audit-timestamp columns
+  (`creation_ts`/`update_ts`), the drafter emits the test at COLUMN scope
+  under the timestamp column, when the variant is type-level model-only
+  (`column: None = None`). The parser correctly rejects with
+  `LLMOutputAnchorContractError`. This surfaced ONLY because Phase B's
+  AST synthesizer correctly merged Intuit's `PREDEFINED_AUDIT_COLUMNS`;
+  Phase A's hand-written demo schema for `weekly_query_cost` omitted them.
+  Worked around in Phase B v3 via `llm.exclude_tests`. Filed as a tracked
+  follow-on.
+- **One additional ops finding** outside the three primitives: `datashare_googlead`
+  (170 columns) blew the safety-layer `_AUDIT_RECORD_LIMIT_BYTES = 4000` cap
+  (`safety-layer.md` DEC-011) at 4,519 bytes. Filed as a tracked follow-on.
+
+The whole exercise consumed ~17 drafter calls + ~4,044 grade calls,
+~$3–7 in Anthropic spend, ~95 min wall-clock end-to-end.
+
+## Substrate
+
+- Repo: `~/Projects/intuit_airflow` (Airflow + dbt 1.8 + Snowflake).
+  Sibling repo to SignalForge; previously stood up for the 2026-05-30
+  baseline measurement that motivated #179.
+- dbt project root: `plugins/dbt/`.
+- `signalforge.yml` in `plugins/dbt/` with `safety.mode: schema-only` and
+  `prune.enabled: false` (the operator has no Snowflake auth against
+  Intuit's `CMB47364.us-east-1` account).
+- Test declarations live in the Python annotation layer at `plugins/models/`
+  rather than schema.yml. `dbt parse` synthesises `target/manifest.json` from
+  schema.yml alone, so each candidate model needed a synthesised
+  `_signalforge_phaseB_schema.yml` for SignalForge to see its columns. The
+  AST-based synthesiser lives at `/tmp/phaseB_synth.py` (transient; not
+  committed). It correctly merges `PREDEFINED_AUDIT_COLUMNS` per the Intuit
+  convention — this is what surfaced the #171 calibration bug.
+
+## Phase A — single-model retest on `weekly_query_cost.sql`
+
+**Goal:** the epic's binary acceptance criteria for #169 and #170, evaluated
+against the same model used for the 2026-05-30 baseline.
+
+```bash
+signalforge generate models/reporting/weekly_query_cost.sql \
+    --project-dir . \
+    --profiles-dir /tmp/sf-demo-profiles \
+    --format markdown
+```
+
+| Primitive | Baseline (5 prims) | Post-shipped (8 prims) | Binary criterion | Result |
+|---|---|---|---|---|
+| #169 `row_count_between` | 0 | **0** | "Drafter MUST propose `row_count_between` on `weekly_query_cost.sql`" | ❌ **FAIL** |
+| #170 `unique_combination` | 1 freeform `custom_sql` `GROUP BY query_signature, query_type HAVING COUNT(*)>1` | **1 structured** `dbt_utils.unique_combination_of_columns: [query_signature, query_type]` | "Drafter produces structured `unique_combination` instead of freeform `custom_sql` on `weekly_query_cost.sql`" | ✅ **PASS** |
+
+Drafter-output delta: 19 tests → 18 tests; `not_null` 8→6, `custom_sql` 9→7
+(the two `GROUP BY HAVING` customs collapsed into one structured
+`unique_combination`).
+
+Cache-stability evidence the system prompt actually grew per
+`business-rule-tests.md` § "Lockstep `_PROMPT_VERSION` rotation":
+
+| Run | `prompt_version` | `cache_creation_input_tokens` |
+|---|---|---|
+| Baseline (2026-05-30) | `c9e7ee1f6f465933` | 1,363 |
+| Phase A (today) | `c11a73cc95b31614` | 2,274 (+67%) |
+
+The +911-token jump aligns with the three new catalogue entries +
+two new scope-instruction blocks landing per
+`business-rule-tests.md` § "Lockstep `_PROMPT_VERSION` rotation".
+
+### Root cause for #169's binary FAIL — named shape
+
+Comparing prompt surfaces across the three new variants in
+`src/signalforge/draft/prompts.py`:
+
+| Variant | Catalogue line | SCOPE-instruction block | "Propose when…" guidance |
+|---|---|---|---|
+| `unique_combination` (#170) | ✅ | ✅ `_UNIQUE_COMBINATION_SCOPE_INSTRUCTION` | "Propose this when the model's grain is a composite key — e.g. `(order_id, line_item_id)`…" |
+| `row_count_anomaly_by_period` (#171) | ✅ | ✅ `_ROW_COUNT_ANOMALY_SCOPE_INSTRUCTION` | "Propose this variant when the model is an incremental fact table whose projection includes `loaded_at` / `created_at` / `event_date`…" |
+| `row_count_between` (#169) | ✅ | ❌ **None** | ❌ **None** |
+
+`plans/super/169-row-count-between.md` **DEC-012** specifies the worked
+example that was supposed to ship: *"When the SQL shows a bounded aggregation
+(`GROUP BY` + date-window `WHERE`), propose `row_count_between` with
+calibrated `minimum` ≥ 1 to catch upstream pipeline gaps."* A `grep` over
+`prompts.py` confirms this guidance never landed.
+
+`weekly_query_cost.sql` is *exactly* that shape — the worked-example
+fixture in DEC-012 itself, the model that originally motivated #169 — and
+the drafter still skipped row_count_between. Strong evidence the
+scope-instruction is the proximate cause, not a fundamental drafter
+calibration ceiling.
+
+## Phase B — aggregate retest across 15 candidate models
+
+### Candidates
+
+Picked from the 98 files declaring
+`dbt_expectations.expect_table_row_count_to_be_between` and the 13 declaring
+`dbt_utils.unique_combination_of_columns` in `plugins/models/`. Five candidates
+double-declare both; ten declare row_count_between only. Mix of subdirectories
+(raw / analytical / reporting / operational / ingress). 7–170 columns each.
+
+```
+5 unique_combination (+ row_count_between):
+  raw/taxday_auction_insights        (16 cols, 9 spaced/quoted)
+  analytical/tvp_yelp                (58 cols)
+  analytical/core_hourly_performance (16 cols, 8 spaced/quoted)
+  raw/taxday_mappings                ( 7 cols)
+  raw/googleads_auction_insights     (15 cols, 9 spaced/quoted)
+
+10 row_count_between only:
+  reporting/data_store_test_control  (61 cols, 11 spaced/quoted)
+  operational/map_cid_sa360          (16 cols)
+  analytical/fiscal_season           (12 cols)
+  raw/query_history                  (21 cols)
+  raw/concord_sku                    (12 cols)
+  raw/aio                            (14 cols)
+  analytical/calendar_hour           ( 8 cols)
+  ingress/yelp_business_metrics_stg  (35 cols)
+  reporting/cid_all_concord_sku      (43 cols, 22 spaced/quoted)
+  raw/datashare_googlead             (170 cols)
+```
+
+### The drafter-calibration bug for #171 (surfaced in v1/v2 before workaround)
+
+Phase B v1 (default config) and v2 (with `llm.max_output_tokens: 16384` to
+fix an unrelated `stop_reason='max_tokens'` truncation on the 58-column
+`tvp_yelp`) both failed on the first 2–3 candidates with identical shape:
+
+```
+ERROR: LLM response violated the anchor contract (4 violation(s)).
+  - column test on column='creation_ts' references None
+  - test references nonexistent column None (available: [...])
+  - column test on column='update_ts' references None
+  - test references nonexistent column None (available: [...])
+```
+
+Every Phase B candidate model carries `creation_ts` + `update_ts` via
+`PREDEFINED_AUDIT_COLUMNS` (the Intuit convention; correctly merged by
+the AST synthesiser). The drafter sees those columns and emits
+`row_count_anomaly_by_period` at COLUMN scope under them — but the
+variant's type-level `column: None = None` constraint makes the resulting
+candidate `test.column = None` while sitting in column scope. The parser
+correctly rejects.
+
+**Why Phase A missed it:** the hand-written
+`_signalforge_demo_schema.yml` for `weekly_query_cost.sql` omitted
+`creation_ts`/`update_ts`; Phase A had no audit-timestamp column for the
+drafter to anchor to. Phase B's broader column coverage IS what made
+this bug visible.
+
+**Hypothesised root cause:** the `_ROW_COUNT_ANOMALY_SCOPE_INSTRUCTION`
+text reads *"Propose this variant when the model is an incremental fact
+table whose projection includes `loaded_at` / `created_at` / `event_date` /
+`partition_date`"* — naming column names without sufficiently emphasising
+"the test goes at MODEL scope, not under the date column's tests list."
+The drafter pattern-matches `creation_ts ≈ created_at` and over-anchors.
+
+**Phase B v3 workaround:**
+
+```yaml
+llm:
+  exclude_tests:
+  - row_count_anomaly_by_period
+```
+
+per the documented operator escape hatch (`llm-drafter.md` §
+"`exclude_tests` dual-defence"). All 15 candidates were re-attempted with
+this in place.
+
+### Phase B v3 results (with `exclude_tests` workaround)
+
+```
+PER-MODEL BREAKDOWN
+taxday_auction_insights     row_count_between    shape-missed
+taxday_auction_insights     unique_combination   shape-matched   column-set exact match
+tvp_yelp                    row_count_between    shape-matched
+tvp_yelp                    unique_combination   shape-matched   column-set overlap (declared=[BUSINESS_ID, CID, DATE], proposed=[BUSINESS_ID, DATE])
+core_hourly_performance     row_count_between    shape-missed
+core_hourly_performance     unique_combination   shape-matched   column-set exact match
+taxday_mappings             row_count_between    shape-matched
+taxday_mappings             unique_combination   shape-matched   column-set exact match
+googleads_auction_insights  row_count_between    shape-missed
+googleads_auction_insights  unique_combination   shape-matched   column-set exact match
+data_store_test_control     row_count_between    shape-matched
+map_cid_sa360               row_count_between    shape-matched
+fiscal_season               row_count_between    shape-matched
+query_history               row_count_between    shape-matched
+concord_sku                 row_count_between    shape-matched
+aio                         row_count_between    shape-missed
+calendar_hour               row_count_between    shape-matched
+yelp_business_metrics_stg   row_count_between    shape-missed
+cid_all_concord_sku         row_count_between    shape-missed
+datashare_googlead          row_count_between    generate-failed  ERROR: Audit record size 4519 exceeds atomic-append limit 4000.
+
+AGGREGATE
+row_count_between           matched= 8  missed= 6  failed= 1  evaluable= 14/15  coverage=  57.1%
+unique_combination          matched= 5  missed= 0  failed= 0  evaluable=  5/5   coverage= 100.0%
+```
+
+### Comparison to epic projections
+
+| Primitive | Epic projection | Phase B measured | Delta | Within ±5 pp? |
+|---|---|---|---|---|
+| `row_count_between` (#169) | 7% → 76% (+69 pp) | 57.1% (8/14) | **-18.9 pp** | ❌ No |
+| `unique_combination` (#170) | 76% → 86% (+10 pp combined) | 100% (5/5) | +14.0 pp | ✅ Yes (above) |
+
+The `row_count_between` measured delta is outside the epic's ±5 pp window.
+Per the epic acceptance criterion: *"if the measured uplift is materially
+lower, the close-out names the specific shapes that fell through — those
+become follow-on prompt-engineering or grading tickets, not silent
+acceptance."*
+
+### The 6 row_count_between misses — named shapes
+
+3 of the 6 misses (taxday_auction_insights, core_hourly_performance,
+googleads_auction_insights) are precisely the models that ALSO declare
+unique_combination. On those models, the drafter proposed
+`unique_combination` correctly but did not also propose `row_count_between`.
+**Hypothesis: the drafter treats composite-key uniqueness as the primary
+grain-stability test and treats the row-count band as redundant.** Whether
+the Intuit team's having declared both is itself good practice is a separate
+question; for the empirical retest, this is a 21.4-pp coverage cost (3/14)
+from a single drafter calibration choice.
+
+The remaining 3 misses (aio, yelp_business_metrics_stg, cid_all_concord_sku)
+are row_count_between-only declarations across raw / ingress / reporting
+subdirs. They don't share an obvious axis with the first three; they may
+simply be the proximate-cause cluster: the **missing
+`_ROW_COUNT_BETWEEN_SCOPE_INSTRUCTION`** identified in Phase A.
+
+Drafter calibration for `(min, max)` values declared per model is NOT
+measured here — the analyser flags presence/absence of the primitive only.
+A separate measurement comparing drafted bounds against Intuit's declared
+`min_value` (frequently `100`) would be one more follow-on.
+
+### `datashare_googlead` — separate ops-class finding
+
+The 170-column model produced an `LLMRequest` whose
+`RedactionRecord`-bearing audit record was 4,519 bytes — over the
+`_AUDIT_RECORD_LIMIT_BYTES = 4000` cap defined in `safety-layer.md` DEC-011.
+`safety.audit.write` correctly raised `AuditRecordTooLargeError` BEFORE any
+file open per the fail-closed contract. The cap is load-bearing for
+atomic JSONL concurrent appends (`PIPE_BUF` floor) and shouldn't be raised
+casually; the right fix lives in the safety layer — either chunk the
+record, scope it down, or surface a clearer remediation that the operator
+can act on.
+
+## Cost + wall time
+
+LLM corpus:
+- 17 drafter calls (Phase A + Phase B v1/v2 attempts + 14 Phase B v3 successes).
+  Total `cache_creation_input_tokens = 31,105`.
+- 4,044 grade calls (one per `(artifact × criterion)` per model — the
+  per-call ratio dropped from `~67/model` on Phase A's `weekly_query_cost`
+  toward the higher end on `datashare_googlead`'s 170 cols, even though
+  that run failed before grading).
+
+Estimated spend: **~$3–7** at sonnet-4-6 published pricing
+(`$3/M` input · `$3.75/M` cache write · `$0.30/M` cache read · `$15/M` output).
+Wall clock: **~95 min end-to-end** (Phase A ~6 min, Phase B v1 ~2 min,
+Phase B v2 ~3 min, Phase B v3 ~76 min, fixed-cost analysis + writeup ~8 min).
+
+## Follow-on tickets to file
+
+The retest produced three actionable follow-ons + one deferred phase. None
+of them are 1-line fixes; each has design decisions to make.
+
+### Follow-on 1 — `_ROW_COUNT_BETWEEN_SCOPE_INSTRUCTION` (the Phase A binary FAIL)
+
+Add `_ROW_COUNT_BETWEEN_SCOPE_INSTRUCTION` to
+`src/signalforge/draft/prompts.py` mirroring `_UNIQUE_COMBINATION_SCOPE_INSTRUCTION`
+and `_ROW_COUNT_ANOMALY_SCOPE_INSTRUCTION`'s pattern. Ship the
+`plans/super/169-row-count-between.md` DEC-012 worked example verbatim.
+Rotate `_PROMPT_VERSION` + `tests/llm/test_prompt_cache_stability.py`
+snapshot in lockstep per `business-rule-tests.md` § "Lockstep
+`_PROMPT_VERSION` rotation."
+
+Expected impact (extrapolating from Phase A's binary): unblocks the
+`weekly_query_cost.sql` case and likely a fraction of the
+aio / yelp_business_metrics_stg / cid_all_concord_sku misses (the cluster
+that doesn't double-declare unique_combination).
+
+### Follow-on 2 — #171 drafter mis-scopes `row_count_anomaly_by_period`
+
+When the manifest carries `creation_ts`/`update_ts`/any-timestamp column,
+the drafter emits `row_count_anomaly_by_period` at COLUMN scope. The
+variant is type-level model-only. Two complementary fixes worth
+considering:
+
+- **Prompt-side**: rewrite `_ROW_COUNT_ANOMALY_SCOPE_INSTRUCTION` to
+  explicitly say *"this test goes in the model-level `tests:` list, NOT
+  inside any column's `tests:` list — the `date_column` argument names the
+  column but the test itself is model-scoped."* Add a worked-example
+  catalogue line that shows the JSON shape at model scope.
+
+- **Parser-side defence-in-depth**: when a model-level-only variant
+  (currently `row_count_between`, `unique_combination`,
+  `row_count_anomaly_by_period`) appears inside a column's `tests:`
+  array, the parser could re-attach it to model scope rather than raising
+  `LLMOutputAnchorContractError`. Deferred decision — it depends on
+  whether the prompt-side fix is enough. Without it, every Intuit-shape
+  manifest (audit-timestamp columns are extremely common) is broken on
+  `signalforge generate` until the operator finds the
+  `llm.exclude_tests` escape hatch.
+
+Carries through to `tests/research/` retest scripts — Phase B's `signalforge.yml`
+override is the operator-visible workaround until this lands.
+
+### Follow-on 3 — audit-record size cap on wide-table models
+
+`safety.AuditRecordTooLargeError` blocks `signalforge generate` on
+`datashare_googlead.sql` (170 columns; 4,519-byte record). Three
+options on the table:
+
+- Chunk the `RedactionRecord` map across multiple audit lines (preserves
+  the 4,000-byte atomic-append floor; needs a new schema-version bump).
+- Lift the cap with care (the per-line cap is load-bearing for atomic
+  concurrent appends; raising it ≥`PIPE_BUF` would break under multi-process
+  audit writers).
+- Compress the `RedactionRecord` map to symbol-tabled column references
+  (most names repeat across rows in a wide-table fixture).
+
+This is a real product limitation worth surfacing — operators with
+wide-table dbt projects (CDC unions, BI rollups) will hit it.
+
+### Deferred — #171 calibration retest (Phase C of the epic)
+
+Requires a maintainer-controlled Snowflake fixture warehouse loaded with
+30+ days of historical data per the epic's option 3. Not run here. File as
+a tracking ticket noting the Snowflake fixture-build dependency.
+
+### Optional — manifest synthesis for code-gen layered dbt projects
+
+Phase B's per-candidate `_signalforge_phaseB_schema.yml` synthesis was a
+real operator burden (~10 min manual schema-yaml work per model, even with
+the AST synthesiser). For dbt projects that use a code-gen layer above
+schema.yml (Intuit is one), a `signalforge ingest --from-meta` helper that
+reads operator-supplied column lists would close the gap. Epic flagged this
+as v0.x prioritisation. Worth its own scoping ticket.
+
+## Reproducing this retest
+
+All driver scripts are transient (`/tmp/phaseB_*`) and have not been
+committed. The substrate is sufficient to reproduce:
+
+```bash
+cd ~/Projects/intuit_airflow/plugins/dbt
+export DBT_PROFILES_DIR=$(pwd) DBT_TMP_DIR=$(pwd) \
+       DBT_SNOWFLAKE_USER=dummy DBT_SNOWFLAKE_PRIVATE_KEY=dummy \
+       DBT_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=dummy
+~/Projects/intuit_airflow/.venv-dbt/bin/dbt parse
+# then for each candidate:
+~/Projects/intuit_airflow/.venv-dbt/bin/signalforge generate \
+    models/<subdir>/<model>.sql --project-dir . \
+    --profiles-dir /tmp/sf-demo-profiles --format markdown
+```
+
+The 2026-05-30 baseline sidecars are preserved at
+`~/Projects/intuit_airflow/plugins/dbt/.signalforge.baseline-2026-05-30/`.
+The Phase B v3 sidecars are at `/tmp/phaseB/` (not durable; survives only
+until next `/tmp` clean).
+
+If the retest moves into `tests/research/` as the epic outlined, the
+synthesiser at `/tmp/phaseB_synth.py` is the seed for a maintainable
+fixture script. The current `signalforge.yml` workaround
+(`llm.exclude_tests: [row_count_anomaly_by_period]`) should drop out
+when Follow-on 2 lands.
+
+## References
+
+- Issue **#179** — epic (this writeup is its close-out artefact).
+- Issues **#169 / #170 / #171** — the child stories whose deltas were
+  measured.
+- `plans/super/169-row-count-between.md` DEC-012 — the worked example
+  that didn't land in `prompts.py` (Follow-on 1).
+- `.claude/rules/business-rule-tests.md` § "Lockstep `_PROMPT_VERSION`
+  rotation" — the lockstep contract the next `prompts.py` change rotates.
+- `.claude/rules/llm-drafter.md` § "Cached-block scope" — the cache TTL
+  + token budget the cache-stability snapshot pins.
+- `.claude/rules/safety-layer.md` DEC-011 — the audit-record size cap
+  Follow-on 3 lives under.
+- `~/Projects/intuit_airflow/plugins/dbt/.signalforge.baseline-2026-05-30/`
+  — preserved 2026-05-30 baseline sidecars (the comparison anchor).


### PR DESCRIPTION
Close-out artefact for epic #179 (Test Generation Expansion).

## What this PR adds

`docs/research/179-test-primitive-expansion-retest.md` (404 lines) — the
empirical retest of #169 / #170 / #171 against the `intuit_airflow`
substrate originally stood up for the 2026-05-30 baseline measurement.

## Results

**Phase A (binary, weekly_query_cost.sql):**
- ✅ #170 `unique_combination` PASS — structured `dbt_utils.unique_combination_of_columns` replaced the baseline's freeform `GROUP BY HAVING`.
- ❌ #169 `row_count_between` FAIL — drafter skipped despite the model being the literal DEC-012 worked-example fixture. Root cause: `_ROW_COUNT_BETWEEN_SCOPE_INSTRUCTION` never landed in `prompts.py`.

**Phase B (aggregate, 15 candidates):**

| Primitive | Measured | Projected | Delta |
|---|---|---|---|
| `row_count_between` (#169) | 57.1% (8/14) | 76% | -18.9 pp ❌ |
| `unique_combination` (#170) | 100.0% (5/5) | 86% | +14.0 pp ✅ |

## Findings to be filed as separate follow-on issues

1. `_ROW_COUNT_BETWEEN_SCOPE_INSTRUCTION` + DEC-012 worked example (Phase A FAIL root cause).
2. Drafter mis-scopes `row_count_anomaly_by_period` to date columns on every model with audit timestamps (#171 calibration bug; reproduced 3/3 in Phase B v1/v2 before workaround).
3. `AuditRecordTooLargeError` blocks `generate` on wide-table models (`datashare_googlead`, 170 cols → 4,519-byte record vs. 4,000-byte cap from `safety-layer.md` DEC-011).

## Phase C (#171 calibration retest)

Deferred — requires a maintainer-controlled Snowflake fixture warehouse per the epic's option 3.

## Cost + wall

~17 drafter + 4,044 grade calls; ~\$3–7 LLM spend; ~95 min wall-clock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added research documentation detailing testing workflows, validation results, and process improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->