### PR TITLE
feat(diff): brand-hex truecolor tier palette with 16-color fallback (#209)

### DIFF
--- a/.claude/rules/diff-renderer.md
+++ b/.claude/rules/diff-renderer.md
@@ -83,6 +83,20 @@ Both `AnsiRenderer` and `MarkdownRenderer` invoke this on every user-content fie
 
 Does NOT cover OSC (`\x1b]...`), DCS (`\x1bP...`), or other non-CSI escapes — out of scope for v0.1; broaden only on a real-world incident.
 
+## Brand-hex truecolor palette is a SECOND axis below the colour-on decision (issue #209)
+
+The verdict vocabulary (`kept` / `kept-uncertain` / `dropped` / `flagged`) is the heart of the brand, so `AnsiRenderer` paints the four tiers in the SignalForge Design-System hues when the terminal supports 24-bit colour. **This is a refinement of "colour is on", a strictly separate axis from the DEC-021 ON/OFF chain — never a way to turn colour on.** Two methods, two questions:
+
+- `_should_emit_color()` (DEC-021) — *is colour on at all?* Unchanged. `NO_COLOR` / `FORCE_COLOR` / `--no-color` / `isatty` resolve here.
+- `_should_emit_truecolor()` (issue #209) — *given colour is on, which palette?* Resolved in `render()` as `truecolor = emit_color and self._should_emit_truecolor()`, so the truecolor branch is dead when colour is off. Resolution: explicit `truecolor` constructor kwarg (`True`/`False`) wins; else `COLORTERM ∈ {truecolor, 24bit}` (case-insensitive, via `_TRUECOLOR_COLORTERM_VALUES`). Unset / unknown `COLORTERM` → the 16-colour fallback.
+
+Load-bearing invariants:
+
+- **Brand hex lives in ONE constant block** (`_TC_SIGNAL`/`_TC_STEEL`/`_TC_NOISE`/`_TC_FLAG` = `#2FCB7F`/`#4F90F7`/`#FB5A60`/`#F5A623`, built via `_truecolor(r,g,b) -> "\x1b[38;2;r;g;bm"`), mirroring `tokens/colors.css`. The two tier→SGR maps (`_TIER_CODES_16`, `_TIER_CODES_TRUECOLOR`) are selected by the static `_tier_codes(truecolor)`. The header counts, the table tier cells, AND the proposed-test-files `+++` header (kept-tier hue) all read the same map so the surfaces stay consistent — don't hardcode a tier colour anywhere else.
+- **16-colour output is byte-identical to pre-#209.** The fallback map reuses the historic `_GREEN`/`_CYAN`/`_RED`/`_YELLOW` codes; every existing `*.ansi` snapshot regenerates unchanged. The new `truecolor_tiers.ansi` golden (case-count `13 → 14` in `test_snapshot_fixtures.py`) pins the brand-hex bytes.
+- **Determinism over ambient env.** Snapshot recipes pass `truecolor` explicitly (`render_for_case` defaults ANSI cases to `False`; the truecolor case sets `True`), and `tests/diff/test_renderers.py` has an autouse fixture clearing `COLORTERM`. A maintainer whose shell exports `COLORTERM=truecolor` must not flip the 16-colour goldens/assertions — any new test asserting a specific 16-colour code MUST pin `truecolor=False` or rely on that fixture; any test asserting brand hex MUST `setenv COLORTERM` or pass `truecolor=True`.
+- **No CLI flag, no `DiffConfig` field in v0.x.** Detection is automatic; the `truecolor` kwarg exists for tests + a future `--color-mode` wiring point. The orchestrator's `_build_renderer` constructs `AnsiRenderer(config=config)` (no override), so a live truecolor terminal gets brand hues for free. If a future ticket adds a `--color-mode {auto,truecolor,16,none}` flag, follow the 5-surface parity rule (`cli-layer.md`).
+
 ## Markdown table-cell escape with HTML entities, raw passthrough inside fenced diff (DEC-008)
 
 `signalforge.diff._markdown_safety.escape_markdown_scalar(text, in_table_cell=False)`:

--- a/docs/diff-ops.md
+++ b/docs/diff-ops.md
@@ -176,6 +176,22 @@ renderer's own colour codes get emitted on top. A drafted column
 description containing `\x1b[31mevil` cannot inject colour into the
 rendered output regardless of the operator's terminal setting.
 
+**Brand-hex truecolor palette (issue #209).** Once the precedence chain
+resolves "colour ON", a second, orthogonal decision picks the *palette*:
+when the terminal advertises 24-bit colour (`COLORTERM=truecolor` or
+`COLORTERM=24bit`), the four verdict tiers paint in the SignalForge
+Design-System hues — `kept` signal-green `#2FCB7F`, `kept-uncertain`
+steel-blue `#4F90F7`, `dropped` noise-red `#FB5A60`, `flagged`
+flag-amber `#F5A623` — in both the summary header counts and the table
+tier cells. Without that advertisement the renderer falls back to the
+16-colour codes (green / cyan / red / yellow), byte-identical to the
+pre-#209 output. The capability tier sits **above** 16-colour and never
+below the colour-OFF decision — the brand palette is a refinement of
+"colour is on", never a way to turn colour on (`NO_COLOR` still wins).
+The `AnsiRenderer(truecolor=...)` constructor kwarg (`True` / `False` /
+`None`) overrides detection for tests and future wiring; there is no
+CLI flag in v0.x — detection is automatic.
+
 The `MarkdownRenderer` escapes Markdown-injection vectors in table
 cells (DEC-008): triple-backticks, pipe (`|`), backslash (`\`). Raw
 HTML (`<...>`) is HTML-entity-encoded for table cells. **Inside the
@@ -315,10 +331,10 @@ points to that stage's input changing.
 
 | Tier             | Source                                                                                                                                                                                                                                                                                                                                                                            | One-line `why` example                                              | Display in `ansi` renderer            |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------- |
-| `kept`           | `PruneDecision.decision == "kept"` AND `PruneDecision.reason == "kept"` (positive prune evidence). No grading report OR grading passed.                                                                                                                                                                                                                                              | "kept by prune; clarity 0.85, consistency 0.90"                     | green, full row                       |
-| `kept-uncertain` | `PruneDecision.decision == "kept"` AND `PruneDecision.reason == "kept-without-evidence"` (issue #50). The prune layer could not positively evaluate the test — total budget exhausted, identifier rejected by SQL safety check, warehouse call raised, `prune.enabled: false`, or sample materialisation failed. **Origin dominates over grading** — never collapses to `flagged`. | "total prune budget exceeded before evaluation"                     | cyan, full row, no score              |
-| `dropped`        | `PruneDecision.decision == "dropped"`. `drop_reason` carries the prune layer's `DropReason` literal.                                                                                                                                                                                                                                                                                | "always-passes (sample of 10000 rows; 0 failing rows)"              | red, dimmed row                       |
-| `flagged`        | Kept by prune (with positive evidence) AND grading is below threshold (any criterion failed OR `score=None` degraded sentinel).                                                                                                                                                                                                                                                    | "passed prune; clarity 0.30 (failed)"                               | yellow, full row with score badge     |
+| `kept`           | `PruneDecision.decision == "kept"` AND `PruneDecision.reason == "kept"` (positive prune evidence). No grading report OR grading passed.                                                                                                                                                                                                                                              | "kept by prune; clarity 0.85, consistency 0.90"                     | green (brand signal `#2FCB7F` on truecolor), full row |
+| `kept-uncertain` | `PruneDecision.decision == "kept"` AND `PruneDecision.reason == "kept-without-evidence"` (issue #50). The prune layer could not positively evaluate the test — total budget exhausted, identifier rejected by SQL safety check, warehouse call raised, `prune.enabled: false`, or sample materialisation failed. **Origin dominates over grading** — never collapses to `flagged`. | "total prune budget exceeded before evaluation"                     | cyan (brand steel `#4F90F7` on truecolor), full row, no score |
+| `dropped`        | `PruneDecision.decision == "dropped"`. `drop_reason` carries the prune layer's `DropReason` literal.                                                                                                                                                                                                                                                                                | "always-passes (sample of 10000 rows; 0 failing rows)"              | red (brand noise `#FB5A60` on truecolor), dimmed row |
+| `flagged`        | Kept by prune (with positive evidence) AND grading is below threshold (any criterion failed OR `score=None` degraded sentinel).                                                                                                                                                                                                                                                    | "passed prune; clarity 0.30 (failed)"                               | yellow (brand flag `#F5A623` on truecolor), full row with score badge |
 
 `flagged` is set only when `grading_report is not None` AND the entry's
 grading is below threshold AND the prune decision had positive evidence.

--- a/src/signalforge/diff/_renderers.py
+++ b/src/signalforge/diff/_renderers.py
@@ -104,6 +104,58 @@ _DIM = "\x1b[2m"
 
 
 # ---------------------------------------------------------------------------
+# Brand-hex truecolor palette (issue #209).
+#
+# The verdict vocabulary (kept / kept-uncertain / dropped / flagged) is "the
+# heart of the brand" — the SignalForge Design System assigns each tier a
+# specific hue (``tokens/colors.css``). When the terminal advertises 24-bit
+# colour, AnsiRenderer paints the tiers in those exact brand hues; otherwise it
+# falls back to the 16-colour SGR codes above. The capability tier sits ABOVE
+# 16-colour and never below the NO_COLOR / colour-off decision — the brand
+# palette is a *refinement* of "colour is on", never a way to turn colour on.
+# ---------------------------------------------------------------------------
+
+
+def _truecolor(r: int, g: int, b: int) -> str:
+    """Return a 24-bit foreground SGR escape for an RGB triple.
+
+    ``\\x1b[38;2;R;G;Bm`` is the ISO 6429 / ECMA-48 direct-colour form
+    supported by truecolor terminals. The renderer emits these only when
+    :meth:`AnsiRenderer._should_emit_truecolor` resolves true.
+    """
+    return f"\x1b[38;2;{r};{g};{b}m"
+
+
+# Brand hex → truecolor SGR (mirrors ``tokens/colors.css`` of the Design
+# System). Each value is the foreground colour for its verdict tier.
+_TC_SIGNAL = _truecolor(0x2F, 0xCB, 0x7F)  # signal green #2FCB7F — kept
+_TC_STEEL = _truecolor(0x4F, 0x90, 0xF7)  # steel blue   #4F90F7 — kept-uncertain
+_TC_NOISE = _truecolor(0xFB, 0x5A, 0x60)  # noise red    #FB5A60 — dropped
+_TC_FLAG = _truecolor(0xF5, 0xA6, 0x23)  # flag amber   #F5A623 — flagged
+
+
+# Tier → SGR maps. The 16-colour map preserves the pre-#209 bytes exactly
+# (kept=green, kept-uncertain=cyan, dropped=red, flagged=yellow); the
+# truecolor map carries the brand hues. :meth:`AnsiRenderer._tier_codes`
+# selects between them per the resolved colour capability.
+_TIER_CODES_16: dict[str, str] = {
+    "kept": _GREEN,
+    "kept-uncertain": _CYAN,
+    "dropped": _RED,
+    "flagged": _YELLOW,
+}
+_TIER_CODES_TRUECOLOR: dict[str, str] = {
+    "kept": _TC_SIGNAL,
+    "kept-uncertain": _TC_STEEL,
+    "dropped": _TC_NOISE,
+    "flagged": _TC_FLAG,
+}
+
+# Truecolor terminal advertisement values for ``COLORTERM`` (lower-cased).
+_TRUECOLOR_COLORTERM_VALUES = frozenset({"truecolor", "24bit"})
+
+
+# ---------------------------------------------------------------------------
 # Renderer ABC.
 # ---------------------------------------------------------------------------
 
@@ -230,6 +282,14 @@ class AnsiRenderer(Renderer):
             :attr:`DiffConfig.respect_no_color_env`. The kwarg exists
             so a caller (CLI / test) can override the config value
             without rebuilding a :class:`DiffConfig`.
+        truecolor: Three-state brand-palette override (issue #209).
+            ``True`` forces the 24-bit brand hues for the verdict tiers,
+            ``False`` forces the 16-colour fallback, ``None`` (the
+            default) auto-detects from the ``COLORTERM`` env var
+            (``truecolor`` / ``24bit``). Orthogonal to the colour
+            ON/OFF chain above — only consulted once colour is on; when
+            colour is off no SGR ships regardless of this value. Tests
+            inject an explicit value for deterministic snapshots.
         terminal_width: Optional terminal-width override for the
             narrow-TTY compact mode (DEC-013). When ``None`` (the
             default), the renderer reads :func:`shutil.get_terminal_size`
@@ -243,6 +303,7 @@ class AnsiRenderer(Renderer):
         config: DiffConfig,
         force_color: bool | None = None,
         respect_no_color_env: bool | None = None,
+        truecolor: bool | None = None,
         terminal_width: int | None = None,
     ) -> None:
         self._config = config
@@ -255,6 +316,11 @@ class AnsiRenderer(Renderer):
             if respect_no_color_env is not None
             else config.respect_no_color_env
         )
+        # Three-state brand-palette override (issue #209). ``True`` forces the
+        # 24-bit brand hues, ``False`` forces the 16-colour fallback, ``None``
+        # auto-detects via ``COLORTERM``. Orthogonal to the colour ON/OFF
+        # decision: only consulted when colour is already on.
+        self._truecolor = truecolor
         self._terminal_width = terminal_width
 
     def render(self, report: DiffReport) -> str:
@@ -274,20 +340,28 @@ class AnsiRenderer(Renderer):
         narrow-TTY (DEC-013) semantics.
         """
         emit_color = self._should_emit_color()
+        # Brand-palette refinement (issue #209): only meaningful once colour
+        # is on. ``truecolor`` selects the 24-bit brand hues vs the 16-colour
+        # fallback for the verdict-tier cells / counts.
+        truecolor = emit_color and self._should_emit_truecolor()
         width = self._effective_width()
         narrow = width < self._config.narrow_terminal_threshold
 
         chunks: list[str] = []
-        chunks.append(self._render_header(report, emit_color=emit_color))
+        chunks.append(self._render_header(report, emit_color=emit_color, truecolor=truecolor))
         chunks.append("")
-        chunks.append(self._render_table(report, narrow=narrow, emit_color=emit_color))
+        chunks.append(
+            self._render_table(report, narrow=narrow, emit_color=emit_color, truecolor=truecolor)
+        )
         chunks.append("")
         chunks.append(self._render_diff_section(report))
         # Issue #116 — proposed standalone ``.sql`` test files (kept
         # ``custom_sql`` business-rule tests). Only appended when the
         # report carries any, so prune-only / schema-only renders stay
         # byte-identical to the pre-#116 output.
-        test_files_section = self._render_test_files_section(report, emit_color=emit_color)
+        test_files_section = self._render_test_files_section(
+            report, emit_color=emit_color, truecolor=truecolor
+        )
         if test_files_section:
             chunks.append("")
             chunks.append(test_files_section)
@@ -330,6 +404,30 @@ class AnsiRenderer(Renderer):
         except (AttributeError, ValueError):  # pragma: no cover — defensive
             return False
 
+    def _should_emit_truecolor(self) -> bool:
+        """Resolve whether to use the 24-bit brand palette (issue #209).
+
+        Only consulted by :meth:`render` AFTER :meth:`_should_emit_color`
+        resolves true — the brand palette refines "colour is on"; it never
+        turns colour on. Resolution:
+
+        1. The explicit ``truecolor`` constructor kwarg wins when not ``None``.
+        2. Otherwise auto-detect via ``COLORTERM`` — ``truecolor`` / ``24bit``
+           (case-insensitive) advertise 24-bit support. Any other value (or an
+           unset var) selects the 16-colour fallback.
+
+        Conservative by design: an unknown / unset ``COLORTERM`` degrades to
+        the 16-colour codes, which every ANSI terminal renders correctly.
+        """
+        if self._truecolor is not None:
+            return self._truecolor
+        return os.environ.get("COLORTERM", "").lower() in _TRUECOLOR_COLORTERM_VALUES
+
+    @staticmethod
+    def _tier_codes(truecolor: bool) -> dict[str, str]:
+        """Return the active tier→SGR map for the resolved colour capability."""
+        return _TIER_CODES_TRUECOLOR if truecolor else _TIER_CODES_16
+
     # ------------------------------------------------------------------
     # Terminal-width detection (DEC-013).
     # ------------------------------------------------------------------
@@ -362,28 +460,37 @@ class AnsiRenderer(Renderer):
             return text
         return f"{code}{text}{_RESET}"
 
-    def _render_header(self, report: DiffReport, *, emit_color: bool) -> str:
+    def _render_header(self, report: DiffReport, *, emit_color: bool, truecolor: bool) -> str:
         """Render the one-line header above the table.
 
         Surfaces the model under render and the three count aggregates.
         ``model_unique_id`` runs through :func:`strip_ansi_escapes`
         UNCONDITIONALLY (DEC-007) — even though manifest unique_ids
         rarely carry escapes, the input boundary is the same defence
-        as the prose ``why`` cell.
+        as the prose ``why`` cell. The per-tier count colours come from
+        the active palette (issue #209) so the brand hues paint the
+        summary line and the table tier cells identically.
         """
+        codes = self._tier_codes(truecolor)
         clean_id = strip_ansi_escapes(report.model_unique_id)
         title = self._color(f"diff: {clean_id}", _BOLD, emit_color=emit_color)
-        kept = self._color(f"kept={report.kept_count}", _GREEN, emit_color=emit_color)
+        kept = self._color(f"kept={report.kept_count}", codes["kept"], emit_color=emit_color)
         kept_uncertain = self._color(
             f"kept-uncertain={report.kept_uncertain_count}",
-            _CYAN,
+            codes["kept-uncertain"],
             emit_color=emit_color,
         )
-        dropped = self._color(f"dropped={report.dropped_count}", _RED, emit_color=emit_color)
-        flagged = self._color(f"flagged={report.flagged_count}", _YELLOW, emit_color=emit_color)
+        dropped = self._color(
+            f"dropped={report.dropped_count}", codes["dropped"], emit_color=emit_color
+        )
+        flagged = self._color(
+            f"flagged={report.flagged_count}", codes["flagged"], emit_color=emit_color
+        )
         return f"{title}  {kept}  {kept_uncertain}  {dropped}  {flagged}"
 
-    def _render_table(self, report: DiffReport, *, narrow: bool, emit_color: bool) -> str:
+    def _render_table(
+        self, report: DiffReport, *, narrow: bool, emit_color: bool, truecolor: bool
+    ) -> str:
         """Render the kept/dropped/flagged table.
 
         Wide mode: 6 columns (tier, artifact_id, test_type, drop_reason,
@@ -397,7 +504,11 @@ class AnsiRenderer(Renderer):
         lines: list[str] = []
         lines.append(self._render_table_header(narrow=narrow, emit_color=emit_color))
         for entry in report.entries:
-            lines.append(self._render_table_row(entry, narrow=narrow, emit_color=emit_color))
+            lines.append(
+                self._render_table_row(
+                    entry, narrow=narrow, emit_color=emit_color, truecolor=truecolor
+                )
+            )
             if narrow:
                 follow = self._render_follow_up_why(entry)
                 if follow:
@@ -423,7 +534,9 @@ class AnsiRenderer(Renderer):
         line = "  ".join(cells)
         return self._color(line, _BOLD, emit_color=emit_color)
 
-    def _render_table_row(self, entry: DiffEntry, *, narrow: bool, emit_color: bool) -> str:
+    def _render_table_row(
+        self, entry: DiffEntry, *, narrow: bool, emit_color: bool, truecolor: bool
+    ) -> str:
         """Render one row of the table.
 
         Every user-content cell — ``artifact_id``, the prose ``why``,
@@ -439,15 +552,13 @@ class AnsiRenderer(Renderer):
         clean_drop_reason = strip_ansi_escapes(entry.drop_reason) if entry.drop_reason else ""
         clean_test_type = strip_ansi_escapes(entry.test_type or "")
 
-        # Tier cell — coloured per-tier via the renderer's own codes.
-        # Issue #50: ``kept-uncertain`` paints cyan to distinguish it
-        # from the green ``kept`` tier (positive prune evidence).
-        tier_colour = {
-            "kept": _GREEN,
-            "kept-uncertain": _CYAN,
-            "dropped": _RED,
-            "flagged": _YELLOW,
-        }.get(entry.tier, _RESET)
+        # Tier cell — coloured per-tier via the active palette. Issue #50:
+        # ``kept-uncertain`` is distinct from the green ``kept`` tier
+        # (positive prune evidence). Issue #209: the brand-hex palette paints
+        # the tier in its Design-System hue when truecolor is active; the
+        # 16-colour map (kept=green/uncertain=cyan/dropped=red/flagged=yellow)
+        # is the fallback.
+        tier_colour = self._tier_codes(truecolor).get(entry.tier, _RESET)
         tier_cell = self._color(_pad(entry.tier, _COL_TIER), tier_colour, emit_color=emit_color)
 
         score_text = "—" if entry.score is None else f"{entry.score:.2f}"
@@ -496,7 +607,9 @@ class AnsiRenderer(Renderer):
         clean_lines = [strip_ansi_escapes(line) for line in body.splitlines()]
         return "\n".join(clean_lines)
 
-    def _render_test_files_section(self, report: DiffReport, *, emit_color: bool) -> str:
+    def _render_test_files_section(
+        self, report: DiffReport, *, emit_color: bool, truecolor: bool
+    ) -> str:
         """Render the proposed standalone ``.sql`` test-file section (#116).
 
         Empty string when ``report.proposed_test_files`` is empty so the
@@ -511,11 +624,14 @@ class AnsiRenderer(Renderer):
         lines: list[str] = []
         heading = self._color("proposed test files:", _BOLD, emit_color=emit_color)
         lines.append(heading)
+        kept_code = self._tier_codes(truecolor)["kept"]
         for proposed in report.proposed_test_files:
             clean_path = strip_ansi_escapes(proposed.path)
-            # ``+++`` new-file header (mirrors the unified-diff +++ shape
-            # so the operator reads it as "this file would be created").
-            header = self._color(f"+++ {clean_path}", _GREEN, emit_color=emit_color)
+            # ``+++`` new-file header (mirrors the unified-diff +++ shape so
+            # the operator reads it as "this file would be created"). Uses the
+            # kept-tier colour (signal green / brand-hex) — a proposed file is
+            # an addition, the same semantic as a kept artifact (issue #209).
+            header = self._color(f"+++ {clean_path}", kept_code, emit_color=emit_color)
             lines.append("")
             lines.append(header)
             for sql_line in proposed.sql.splitlines():

--- a/tests/diff/_snapshot_inputs.py
+++ b/tests/diff/_snapshot_inputs.py
@@ -492,6 +492,7 @@ class _Recipe(_RecipeRequired, total=False):
 
     terminal_width: int
     force_color: bool | None
+    truecolor: bool | None
     no_color_env: bool
     markdown_project_dir: str
 
@@ -606,6 +607,21 @@ CASES: dict[str, tuple[_Builder, _Recipe]] = {
             "markdown_project_dir": "<project_dir>",
         },
     ),
+    # 10c. truecolor_tiers.ansi — same inputs as full_with_grade, but the
+    # 24-bit brand-hex palette (issue #209). Pins the brand-tier SGR bytes
+    # (signal #2FCB7F / steel #4F90F7 / noise #FB5A60 / flag #F5A623) so a
+    # palette regression fails loud. `truecolor=True` makes this deterministic
+    # regardless of the ambient COLORTERM.
+    "truecolor_tiers.ansi": (
+        _full_with_grade_report,
+        {
+            "surface": "ansi",
+            "filename": "truecolor_tiers.ansi",
+            "terminal_width": 120,
+            "force_color": True,
+            "truecolor": True,
+        },
+    ),
     # 11. proposed_test_files.ansi — kept custom_sql standalone files (#116).
     "proposed_test_files.ansi": (
         _proposed_test_files_report,
@@ -661,6 +677,13 @@ def render_for_case(
         return renderer.render(report)
 
     # ansi surface.
+    #
+    # ``truecolor`` defaults to ``False`` here (issue #209) so every existing
+    # ANSI snapshot renders with the 16-colour palette DETERMINISTICALLY —
+    # independent of the ambient ``COLORTERM`` of whoever runs the suite or the
+    # regenerate script. The dedicated ``truecolor_tiers.ansi`` case opts in via
+    # ``"truecolor": True`` to pin the brand-hex palette.
+    truecolor = recipe.get("truecolor", False)
     if recipe.get("no_color_env"):
         # Defensive: if the caller already set NO_COLOR, leave it as is.
         had_prior = "NO_COLOR" in os.environ
@@ -670,6 +693,7 @@ def render_for_case(
             ansi = AnsiRenderer(
                 config=cfg,
                 force_color=recipe.get("force_color"),
+                truecolor=truecolor,
                 terminal_width=recipe.get("terminal_width"),
             )
             return ansi.render(report)
@@ -680,6 +704,7 @@ def render_for_case(
     ansi = AnsiRenderer(
         config=cfg,
         force_color=recipe.get("force_color"),
+        truecolor=truecolor,
         terminal_width=recipe.get("terminal_width"),
     )
     return ansi.render(report)

--- a/tests/diff/test_renderers.py
+++ b/tests/diff/test_renderers.py
@@ -105,6 +105,21 @@ def default_config() -> DiffConfig:
     return DiffConfig()
 
 
+@pytest.fixture(autouse=True)
+def _deterministic_colorterm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear ``COLORTERM`` so colour-palette assertions are deterministic
+    regardless of the runner's terminal (issue #209).
+
+    The 16-colour palette is the baseline the bulk of this module's
+    colour assertions expect; without this, a maintainer whose shell
+    exports ``COLORTERM=truecolor`` would see the brand-hex palette and
+    the 16-colour assertions would spuriously fail. Tests that exercise
+    the truecolor path call ``monkeypatch.setenv("COLORTERM", ...)`` in
+    their own body, which overrides this autouse default.
+    """
+    monkeypatch.delenv("COLORTERM", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # 1. Renderer ABC contract.
 # ---------------------------------------------------------------------------
@@ -343,6 +358,140 @@ def test_color_precedence_isatty_is_terminal_signal(
     renderer = AnsiRenderer(config=default_config, force_color=None, terminal_width=200)
     output = renderer.render(_make_report(entries=(_kept_entry(),)))
     assert "\x1b[" not in output
+
+
+# ---------------------------------------------------------------------------
+# 4b. Brand-hex truecolor palette (issue #209).
+# ---------------------------------------------------------------------------
+
+# Brand-hex 24-bit SGR codes (tokens/colors.css). Asserted as literal bytes so
+# a palette regression — wrong hex, wrong tier mapping — fails loud.
+_TC_KEPT = "\x1b[38;2;47;203;127m"  # signal green #2FCB7F
+_TC_UNCERTAIN = "\x1b[38;2;79;144;247m"  # steel blue #4F90F7
+_TC_DROPPED = "\x1b[38;2;251;90;96m"  # noise red #FB5A60
+_TC_FLAGGED = "\x1b[38;2;245;166;35m"  # flag amber #F5A623
+
+
+def _all_tiers_report() -> DiffReport:
+    """A report carrying one entry of every verdict tier."""
+    entries = (
+        _kept_entry(),
+        DiffEntry(
+            artifact_id="test.column.email.unique",
+            test_type="unique",
+            tier="kept-uncertain",
+            drop_reason=None,
+            why="warehouse unreachable",
+            score=None,
+            passed=None,
+        ),
+        _dropped_entry(),
+        DiffEntry(
+            artifact_id="column.email.description",
+            test_type=None,
+            tier="flagged",
+            drop_reason=None,
+            why="below threshold",
+            score=0.40,
+            passed=False,
+        ),
+    )
+    return _make_report(entries=entries)
+
+
+def test_truecolor_palette_used_when_colorterm_advertises(
+    default_config: DiffConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """COLORTERM=truecolor → the four verdict tiers paint in brand hex,
+    not the 16-colour codes (issue #209 auto-detection)."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    renderer = AnsiRenderer(config=default_config, force_color=True, terminal_width=200)
+    output = renderer.render(_all_tiers_report())
+    assert _TC_KEPT in output
+    assert _TC_UNCERTAIN in output
+    assert _TC_DROPPED in output
+    assert _TC_FLAGGED in output
+    # The 16-colour tier codes must NOT appear when truecolor is active.
+    assert "\x1b[32m" not in output
+    assert "\x1b[36m" not in output
+
+
+def test_truecolor_detected_for_24bit_colorterm(
+    default_config: DiffConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """COLORTERM=24bit is the other recognised truecolor advertisement."""
+    monkeypatch.setenv("COLORTERM", "24bit")
+    renderer = AnsiRenderer(config=default_config, force_color=True, terminal_width=200)
+    output = renderer.render(_all_tiers_report())
+    assert _TC_KEPT in output
+
+
+def test_sixteen_color_fallback_when_colorterm_unset(
+    default_config: DiffConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No COLORTERM advertisement → the 16-colour palette (byte-identical
+    to the pre-#209 output) is used, never the 24-bit codes."""
+    monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    renderer = AnsiRenderer(config=default_config, force_color=True, terminal_width=200)
+    output = renderer.render(_all_tiers_report())
+    assert "\x1b[32m" in output  # green kept
+    assert "\x1b[36m" in output  # cyan kept-uncertain
+    assert "38;2" not in output  # no truecolor escapes
+
+
+def test_truecolor_kwarg_true_overrides_detection(
+    default_config: DiffConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``truecolor=True`` forces the brand palette even with COLORTERM unset."""
+    monkeypatch.delenv("COLORTERM", raising=False)
+    renderer = AnsiRenderer(
+        config=default_config, force_color=True, truecolor=True, terminal_width=200
+    )
+    output = renderer.render(_all_tiers_report())
+    assert _TC_KEPT in output
+    assert "\x1b[32m" not in output
+
+
+def test_truecolor_kwarg_false_overrides_detection(
+    default_config: DiffConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``truecolor=False`` forces the 16-colour fallback even when the
+    terminal advertises COLORTERM=truecolor."""
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    renderer = AnsiRenderer(
+        config=default_config, force_color=True, truecolor=False, terminal_width=200
+    )
+    output = renderer.render(_all_tiers_report())
+    assert "\x1b[32m" in output
+    assert "38;2" not in output
+
+
+def test_truecolor_not_emitted_when_color_off(
+    default_config: DiffConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The brand palette refines 'colour on' — it never turns colour on.
+    With colour forced OFF, no SGR ships regardless of ``truecolor=True``."""
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    renderer = AnsiRenderer(
+        config=default_config, force_color=False, truecolor=True, terminal_width=200
+    )
+    output = renderer.render(_all_tiers_report())
+    assert "\x1b[" not in output
+
+
+def test_truecolor_header_counts_use_brand_palette(
+    default_config: DiffConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The summary header's per-tier counts use the same brand hues as the
+    table tier cells (issue #209) so the two surfaces stay consistent."""
+    monkeypatch.setenv("COLORTERM", "truecolor")
+    renderer = AnsiRenderer(config=default_config, force_color=True, terminal_width=200)
+    output = renderer.render(_all_tiers_report())
+    header = output.splitlines()[0]
+    assert f"{_TC_KEPT}kept=1" in header
+    assert f"{_TC_DROPPED}dropped=1" in header
 
 
 # ---------------------------------------------------------------------------

--- a/tests/diff/test_snapshot_fixtures.py
+++ b/tests/diff/test_snapshot_fixtures.py
@@ -121,11 +121,13 @@ def test_dec017_case_count() -> None:
     # DEC-017 enumerates 10 cases; case 10 has both .ansi and .md
     # surfaces, giving 11 on-disk artefacts. Issue #116 adds the
     # proposed-test-files case in both .ansi and .md surfaces (2 more)
-    # for 13 on-disk artefacts.
-    assert len(filenames) == 13, (
-        f"expected 13 snapshot fixture files (10 DEC-017 cases + the "
+    # for 13. Issue #209 adds the truecolor_tiers.ansi brand-palette
+    # case for 14 on-disk artefacts.
+    assert len(filenames) == 14, (
+        f"expected 14 snapshot fixture files (10 DEC-017 cases + the "
         f"injection_payloads markdown variant + the #116 proposed_test_files "
-        f"ansi/markdown variants), got {len(filenames)}: {sorted(filenames)}"
+        f"ansi/markdown variants + the #209 truecolor_tiers.ansi case), got "
+        f"{len(filenames)}: {sorted(filenames)}"
     )
 
 

--- a/tests/fixtures/diff/truecolor_tiers.ansi
+++ b/tests/fixtures/diff/truecolor_tiers.ansi
@@ -1,0 +1,20 @@
+[1mdiff: model.shop.dim_customers[0m  [38;2;47;203;127mkept=2[0m  [38;2;79;144;247mkept-uncertain=1[0m  [38;2;251;90;96mdropped=1[0m  [38;2;245;166;35mflagged=1[0m
+
+[1mTIER            ARTIFACT                      TEST            REASON                  SCORE    WHY[0m
+[38;2;47;203;127mkept          [0m  column.customer_id.descript…                                          0.85     Description added; passed all grading criteria.
+[38;2;47;203;127mkept          [0m  test.column.customer_id.not…  not_null                                —        Test returned non-zero failing rows on the warehouse sample.
+[38;2;79;144;247mkept-uncertain[0m  test.column.email.unique      unique                                  —        total prune budget exceeded before evaluation
+[38;2;251;90;96mdropped       [0m  test.column.customer_id.uni…  unique          always-passes           —        Test returned zero failing rows on the representative sample.
+[38;2;245;166;35mflagged       [0m  column.email.description                                              0.45     Grading score 0.45 below threshold 0.50.
+
+--- a/models/dim_customers.yml
++++ b/models/dim_customers.yml
+@@ -1,5 +1,8 @@
+ version: 2
+ models:
+   - name: dim_customers
+     columns:
+       - name: customer_id
++        description: Surrogate key.
++        tests:
++          - not_null


### PR DESCRIPTION
## What

`AnsiRenderer` now paints the four verdict tiers (`kept` / `kept-uncertain` / `dropped` / `flagged`) in the SignalForge **brand Design-System hues** when the terminal advertises 24-bit colour, falling back to the existing 16-colour SGR codes otherwise.

This is the foundation child (#209) of the brand-CLI epic (#208) — the verdict vocabulary is "the heart of the brand," so its colours come first.

## How

- **Brand palette in one constant block** mirroring `tokens/colors.css`: `#2FCB7F` (kept) / `#4F90F7` (kept-uncertain) / `#FB5A60` (dropped) / `#F5A623` (flagged), via `_truecolor(r,g,b) -> "\x1b[38;2;r;g;bm"`; two tier→SGR maps (`_TIER_CODES_16`, `_TIER_CODES_TRUECOLOR`) selected by `_tier_codes(truecolor)`.
- **`_should_emit_truecolor()` is a second axis below the colour-on chain** — resolved in `render()` as `truecolor = emit_color and self._should_emit_truecolor()`, so the brand palette is a *refinement of "colour is on", never a way to turn colour on*. Detects `COLORTERM ∈ {truecolor, 24bit}`; the `truecolor` constructor kwarg (`True`/`False`/`None`) overrides for tests + future wiring.
- **Header counts, table tier cells, and the proposed-test-files `+++` header** all read the same palette map (one source of truth; no hardcoded tier colour elsewhere).
- **No CLI flag / `DiffConfig` field** (D1's recommendation) — detection is automatic, so `_build_renderer` gives a live truecolor terminal brand hues for free.

## Invariants preserved

- DEC-021 colour-precedence chain (`respect_no_color_env` > `force_color` > `FORCE_COLOR` > `NO_COLOR` > `isatty`) — unchanged.
- DEC-007 unconditional ANSI-strip on user content — unchanged (security boundary).
- AnsiRenderer stays pure-return (DEC-011).
- **16-colour output is byte-identical to pre-#209** — every existing `*.ansi` golden regenerates unchanged; the new `truecolor_tiers.ansi` golden pins the brand-hex bytes (snapshot case count 13 → 14).

## Tests / determinism

- New `test_renderers.py` section: COLORTERM detection, both kwarg overrides, and the colour-off short-circuit.
- Snapshot recipes pass `truecolor` explicitly; an autouse fixture clears `COLORTERM` so 16-colour assertions are independent of the runner's terminal.

## Validation

`uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest` — all green (3725 passed, 8 skipped, 97.25% cov; pyright 0 errors). End-to-end verified through the public `render_to_text` with `COLORTERM=truecolor`.

## Parity surfaces

`docs/diff-ops.md` (colour section + tier table) and `.claude/rules/diff-renderer.md` (new palette section) updated in this commit.

Closes #209. Part of #208.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ANSI 24-bit truecolor support to diff renderer with brand-hex color palettes; automatically detects terminal capabilities via environment variable and displays enhanced colors for verdict tiers when supported.

* **Documentation**
  * Updated renderer and diff-ops documentation explaining truecolor palette selection and automatic detection behavior.

* **Tests**
  * Added comprehensive test coverage for truecolor detection, fallback mechanisms, and manual override functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->