### PR TITLE
feat(cli): end-of-run footer — wrote … + ✓ done in <X> · $cost (#211)

### DIFF
--- a/.claude/rules/cli-layer.md
+++ b/.claude/rules/cli-layer.md
@@ -137,7 +137,7 @@ Load-bearing details:
 
 A successful **single-model** `generate` run closes with a two-line stderr footer, built by `build_run_footer(*, elapsed_seconds, written, dry_run, cost_clause, style)` in `_helpers.py`:
 
-```
+```text
 wrote schema.yml (8 kept) · .signalforge/diff.json · .signalforge/grade.json
 ✓ done in 5m12s · $0.13 Anthropic
 ```

--- a/.claude/rules/cli-layer.md
+++ b/.claude/rules/cli-layer.md
@@ -133,6 +133,23 @@ Load-bearing details:
 - **Test determinism:** `tests/cli/test_generate.py` has an autouse fixture clearing `NO_COLOR`/`FORCE_COLOR`/`COLORTERM` per test — load-bearing because `--no-color` mutates `os.environ["NO_COLOR"]` and does NOT restore it (DEC-023), so an in-process `--no-color` test would otherwise leak the var into every later test and flip its colour path. Colour-path assertions strip SGR and check plain structure (palette-independent); a dedicated test pins the spark-amber SGR under `FORCE_COLOR`+`COLORTERM=truecolor`.
 - **Scope:** `prune-existing` progress stays on the plain path (passes no `style`) in v0.x — only `generate` got the glyph. `--no-grade` still renumbers to `[N/4]` on both surfaces.
 
+## End-of-run footer — `wrote …` + `✓ done in <X> · $cost` (issue #211)
+
+A successful **single-model** `generate` run closes with a two-line stderr footer, built by `build_run_footer(*, elapsed_seconds, written, dry_run, cost_clause, style)` in `_helpers.py`:
+
+```
+wrote schema.yml (8 kept) · .signalforge/diff.json · .signalforge/grade.json
+✓ done in 5m12s · $0.13 Anthropic
+```
+
+Load-bearing rules:
+
+- **Built in `_run_single_model`, emitted by the dispatcher AFTER the stdout diff.** The footer string is stored on `_SingleModelOutcome.footer_text` (`""` on failure / `--quiet` / non-TTY / batch). The dispatcher does `sys.stdout.write(rendered_text)` → `sys.stdout.flush()` → `print_stderr(footer_text, allow_sgr=True, flush=True)` so the footer reads *below* the table and `> diffs.txt` still captures only the diff (stdout). Building it in `_run_single_model` (which returns before stdout is written) and emitting from the dispatcher is the seam — don't emit it inline (it would print above the diff).
+- **Single-model only.** A batch closes with `format_batch_summary`; `_run_single_model` sets `footer_text=""` when `batch_index is not None`. The per-model cost rollup would be *cumulative* (the audit JSONLs are append-only across a `--select` batch), so a per-model `$cost` would mislead. Batch-total cost is a deferred follow-up.
+- **Cost is SUPPLEMENTARY — degrade, never fail (DEC-005).** `cost_module.rollup_audit_dir(project_dir)` is wrapped in a bare `except Exception` that degrades to an empty `cost_clause`. A missing/malformed audit, an unpriced SKU, anything — the run still exits 0 with a bare `✓ done in <X>`. `format_cost_clause(per_provider_usd)` joins providers with subtotal > 0 in sorted-key order; `_format_usd` renders `<$0.01` for a positive-but-sub-cent figure (a `$0.00` would read as free). **Warehouse cost is deliberately omitted** — there is no actual-bytes-scanned figure at end-of-run (only the `--estimate` planner preview), so the clause stays LLM-only rather than fabricating a number.
+- **`wrote` line is HONEST.** It names only artifacts actually written this run: `schema.yml (N kept)` + proposed `.sql` count under `--write`; `.signalforge/diff.json` unless `--dry-run`; `.signalforge/grade.json` when graded. Empty under `--dry-run` → `dry run — no files written`. Never claims a write that didn't happen.
+- **Colour-gated like the progress lines (#210).** The `✓` is signal-green (`palette.SIGNAL`/`GREEN`) — glyph + dim styling only when `style.color`; the colour-off form is plain text (no glyph, no SGR). Gated by `progress_on`, so `--quiet` / non-TTY suppress it. Every fragment is internally constructed (artifact names, formatted USD, provider display) so it's safe through `print_stderr(allow_sgr=True)`.
+
 ## Multi-source CLI commands degrade on supplementary failures (DEC-005 of #36)
 
 When a CLI command (e.g. `--estimate`) has multiple data sources where some are supplementary (e.g. `count_tokens` is load-bearing for cost preview; `adapter.estimate_query_bytes` is nice-to-have), supplementary failures must NOT propagate. Three rules:

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -1242,6 +1242,35 @@ stages: safety, draft, prune, diff). See [Skip grading for fast
 iteration (`--no-grade`)](#skip-grading-for-fast-iteration---no-grade)
 for the cookbook entry.
 
+### End-of-run footer
+
+A successful single-model run closes with a two-line footer on stderr,
+printed below the diff:
+
+```text
+wrote schema.yml (8 kept) · .signalforge/diff.json · .signalforge/grade.json
+✓ done in 5m12s · $0.13 Anthropic
+```
+
+- The **`wrote`** line names the artifacts actually written this run —
+  `schema.yml (N kept)` only under `--write`, `.signalforge/diff.json`
+  unless `--dry-run`, `.signalforge/grade.json` when the grade stage
+  ran. Under `--dry-run` it reads `dry run — no files written`.
+- The **`✓ done`** line carries the wall-clock plus the LLM cost,
+  summed per provider from the run's audit JSONLs
+  (`.signalforge/llm_responses.jsonl` + `grade.jsonl`). A sub-cent
+  figure renders `<$0.01`. Warehouse cost is not shown — there is no
+  actual-bytes-scanned figure at end of run (use `--estimate` for a
+  pre-run planner preview). If the cost can't be computed the run still
+  succeeds with a bare `✓ done in <X>` (the cost is a nice-to-have, not
+  load-bearing).
+
+Like the progress lines, the footer is on stderr (so `> diffs.txt`
+captures only the diff), the `✓` glyph + colour appear only on a colour
+terminal, and `--quiet` / non-TTY suppress it. In a `--select` batch the
+per-model footer is replaced by the aggregate
+[batch summary](#running-across-many-models).
+
 The `<fact>` field on each entry line is computed from objects
 already in scope (model id, candidate test count,
 `kept_count × criteria_count`) so the operator sees the size of the

--- a/src/signalforge/cli/_helpers.py
+++ b/src/signalforge/cli/_helpers.py
@@ -30,6 +30,7 @@ import logging
 import os
 import shutil
 import sys
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
@@ -1006,6 +1007,110 @@ def emit_progress_done(
     fact_clean = strip_ansi_escapes(fact)
     pad = max(2, _progress_terminal_width() - len(left_plain) - len(fact_clean))
     print_stderr(f"{left}{' ' * pad}{_dim(fact_clean, style)}", flush=True, allow_sgr=True)
+
+
+# ---------------------------------------------------------------------------
+# End-of-run footer — ``wrote …`` + ``✓ done in <X> · $cost`` (issue #211)
+# ---------------------------------------------------------------------------
+
+# Human-facing provider display names for the cost clause. Keyed by the
+# canonical registry name (``signalforge.llm.providers``); an unmapped provider
+# falls back to its raw key so a future vendor still renders.
+_PROVIDER_DISPLAY: dict[str, str] = {
+    "anthropic": "Anthropic",
+    "openai": "OpenAI",
+    "gemini": "Gemini",
+}
+
+
+def _check_glyph(style: ProgressStyle) -> str:
+    """Return the coloured ``✓`` success glyph + trailing space, or '' when
+    colour off. Signal-green (brand ``#2FCB7F`` truecolor / 16-colour green
+    fallback) — the same hue the diff renderer paints the ``kept`` tier."""
+    if not style.color:
+        return ""
+    code = palette.SIGNAL if style.truecolor else palette.GREEN
+    return f"{code}✓{palette.RESET} "
+
+
+def _format_usd(value: float) -> str:
+    """Format a USD figure for the cost clause.
+
+    ``$X.XX`` at or above one cent; ``<$0.01`` for a positive-but-sub-cent
+    figure (a two-decimal ``$0.00`` would read as free when it is not).
+    """
+    if 0.0 < value < 0.01:
+        return "<$0.01"
+    return f"${value:.2f}"
+
+
+def format_cost_clause(per_provider_usd: Mapping[str, float]) -> str:
+    """Format the per-provider LLM cost clause for the ``✓ done`` line.
+
+    ``{"anthropic": 0.13}`` → ``"$0.13 Anthropic"``; multiple providers join
+    with `` · `` in sorted-key order for determinism. Providers with a
+    zero/negative subtotal are omitted (a cache-only or no-call run shows no
+    cost clause rather than ``$0.00``). Returns ``""`` when nothing is billable
+    — the caller then emits a bare ``✓ done in <X>`` line.
+
+    Warehouse cost is deliberately NOT included: there is no
+    actual-bytes-scanned figure at end-of-run (only the ``--estimate``
+    planner preview), so the clause stays LLM-only rather than fabricating a
+    number (mirrors the supplementary-failure degrade of ``--estimate``,
+    `cli-layer.md` DEC-005).
+    """
+    parts: list[str] = []
+    for provider in sorted(per_provider_usd):
+        usd = per_provider_usd[provider]
+        if usd <= 0.0:
+            continue
+        display = _PROVIDER_DISPLAY.get(provider, provider)
+        parts.append(f"{_format_usd(usd)} {display}")
+    return " · ".join(parts)
+
+
+def build_run_footer(
+    *,
+    elapsed_seconds: float,
+    written: Sequence[str],
+    dry_run: bool,
+    cost_clause: str,
+    style: ProgressStyle,
+) -> str:
+    """Build the end-of-run footer (issue #211) for a single ``generate`` run.
+
+    Two lines on the colour path::
+
+        wrote schema.yml (8 kept) · .signalforge/diff.json · .signalforge/grade.json
+        ✓ done in 5m12s · $0.13 Anthropic
+
+    * The ``wrote`` line names the artifacts ACTUALLY written this run
+      (``written`` is built by the caller from the ``--write`` / ``--dry-run``
+      / grading state — honest, never a claim of a write that didn't happen).
+      Empty ``written`` under ``--dry-run`` renders ``dry run — no files
+      written``; empty otherwise omits the line.
+    * The ``✓ done`` line carries the wall-clock + the LLM ``cost_clause``
+      (omitted when empty).
+
+    Colour-gated like the progress lines (issue #210): the ``✓`` glyph + the
+    dim styling appear only when ``style.color``; the colour-off form is plain
+    text (no glyph, no SGR). The whole footer is gated by the caller behind
+    ``progress_on`` (so ``--quiet`` / non-TTY suppress it). Every fragment is
+    internally constructed (artifact names, formatted USD, provider display) —
+    no user-content interpolation — so it is safe to emit through
+    ``print_stderr(..., allow_sgr=True)``.
+    """
+    lines: list[str] = []
+    if written:
+        lines.append(f"wrote {_dim(' · '.join(written), style)}")
+    elif dry_run:
+        lines.append(_dim("dry run — no files written", style))
+    timing = f"done in {format_elapsed(elapsed_seconds)}"
+    done = f"{_check_glyph(style)}{timing}"
+    if cost_clause:
+        done = f"{done} · {_dim(cost_clause, style)}"
+    lines.append(done)
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/src/signalforge/cli/_helpers.py
+++ b/src/signalforge/cli/_helpers.py
@@ -1064,7 +1064,11 @@ def format_cost_clause(per_provider_usd: Mapping[str, float]) -> str:
         usd = per_provider_usd[provider]
         if usd <= 0.0:
             continue
-        display = _PROVIDER_DISPLAY.get(provider, provider)
+        # The known display names are literals, but the fallback echoes the
+        # raw provider KEY from the audit JSONL — strip ANSI defensively since
+        # the footer is emitted through ``print_stderr(allow_sgr=True)`` (the
+        # emitter pre-strips every user-content fragment, cli-layer.md #210).
+        display = strip_ansi_escapes(_PROVIDER_DISPLAY.get(provider, provider))
         parts.append(f"{_format_usd(usd)} {display}")
     return " · ".join(parts)
 

--- a/src/signalforge/cli/generate.py
+++ b/src/signalforge/cli/generate.py
@@ -1461,8 +1461,12 @@ def _run_single_model(
                     written.append(f"{n_tests} test file{'s' if n_tests != 1 else ''}")
             if not dry_run:
                 written.append(".signalforge/diff.json")
-            if grade_report is not None:
-                written.append(".signalforge/grade.json")
+                # grade.json is a deliverable sidecar; under --dry-run the
+                # footer reports no deliverables (honours the documented
+                # dry-run contract) even though the grade stage's own sidecar
+                # write is not yet dry-run-aware (pre-existing; out of #211).
+                if grade_report is not None:
+                    written.append(".signalforge/grade.json")
             # Cost is a SUPPLEMENTARY surface (cli-layer.md DEC-005): a rollup
             # failure (missing audit, malformed record, unpriced SKU) must
             # never fail the run — degrade to no cost clause.

--- a/src/signalforge/cli/generate.py
+++ b/src/signalforge/cli/generate.py
@@ -105,11 +105,13 @@ from signalforge import safety as safety_module
 from signalforge import warehouse as warehouse_module
 from signalforge.cli import _estimate as estimate_module
 from signalforge.cli._helpers import (
+    build_run_footer,
     canonicalise_user_path,
     emit_batch_progress_entry,
     emit_progress_done,
     emit_progress_entry,
     format_batch_summary,
+    format_cost_clause,
     format_error_to_stderr,
     map_exception_to_exit_code,
     print_stderr,
@@ -130,6 +132,7 @@ from signalforge.diff._test_file_writer import (
 from signalforge.diff.models import DiffReport, ProposedTestFile
 from signalforge.grade.rubric import DEFAULT_RUBRIC
 from signalforge.llm import AnthropicClientProtocol
+from signalforge.llm import cost as cost_module
 from signalforge.llm.providers import provider_for
 from signalforge.manifest import select_models
 from signalforge.manifest.errors import SelectorParseError
@@ -785,6 +788,13 @@ class _SingleModelOutcome:
       the trailing newline that ``print(rendered)`` produces). Empty
       string on failure so the dispatcher's ``if r.rendered_text`` check
       naturally skips it.
+    * ``footer_text`` — the issue-#211 end-of-run stderr footer (``wrote
+      …`` + ``✓ done in <X> · $cost``). Built ONLY for the single-model
+      success path with progress on; ``""`` on failure, under ``--quiet`` /
+      non-TTY, and for every per-model run inside a batch (the batch path
+      uses :func:`format_batch_summary` as its closing line instead). The
+      dispatcher emits it to stderr AFTER the stdout diff so it reads below
+      the table.
     * ``duration_seconds`` — wall-clock from ``_run_single_model`` entry
       to exit (success or failure).
     * ``exception_class_name`` — ``None`` on success; on failure, the
@@ -804,6 +814,7 @@ class _SingleModelOutcome:
     dropped_count: int
     flagged_count: int
     rendered_text: str
+    footer_text: str
     duration_seconds: float
     exception_class_name: str | None
 
@@ -1053,6 +1064,7 @@ def _run_single_model(
                 dropped_count=0,
                 flagged_count=0,
                 rendered_text="",
+                footer_text="",
                 duration_seconds=time.monotonic() - start,
                 exception_class_name=None,
             )
@@ -1432,6 +1444,44 @@ def _run_single_model(
         # so we pre-build the trailing newline here. ``print``'s default
         # ``end="\n"`` is what every existing snapshot test pins.
         rendered_text = f"{rendered}\n"
+
+        # 7. Build the end-of-run footer (issue #211). Single-model success
+        #    path only: a batch closes with :func:`format_batch_summary`, and a
+        #    per-model cost rollup would be cumulative (the audit JSONLs are
+        #    append-only across the batch). Gated by ``progress_on`` so
+        #    ``--quiet`` / non-TTY suppress it. The dispatcher emits it AFTER
+        #    the stdout diff so it reads below the table.
+        footer_text = ""
+        if progress_on and batch_index is None:
+            written: list[str] = []
+            if write:
+                written.append(f"schema.yml ({diff_report.kept_count} kept)")
+                n_tests = len(diff_report.proposed_test_files)
+                if n_tests:
+                    written.append(f"{n_tests} test file{'s' if n_tests != 1 else ''}")
+            if not dry_run:
+                written.append(".signalforge/diff.json")
+            if grade_report is not None:
+                written.append(".signalforge/grade.json")
+            # Cost is a SUPPLEMENTARY surface (cli-layer.md DEC-005): a rollup
+            # failure (missing audit, malformed record, unpriced SKU) must
+            # never fail the run — degrade to no cost clause.
+            cost_clause = ""
+            try:
+                cost_report = cost_module.rollup_audit_dir(project_dir)
+                cost_clause = format_cost_clause(
+                    {p: r.subtotal_usd for p, r in cost_report.per_provider.items()}
+                )
+            except Exception:  # noqa: BLE001 — supplementary; degrade silently
+                cost_clause = ""
+            footer_text = build_run_footer(
+                elapsed_seconds=time.monotonic() - start,
+                written=written,
+                dry_run=dry_run,
+                cost_clause=cost_clause,
+                style=progress_style,
+            )
+
         return _SingleModelOutcome(
             model_unique_id=model.unique_id,
             exit_code=0,
@@ -1439,6 +1489,7 @@ def _run_single_model(
             dropped_count=diff_report.dropped_count,
             flagged_count=diff_report.flagged_count,
             rendered_text=rendered_text,
+            footer_text=footer_text,
             duration_seconds=time.monotonic() - start,
             exception_class_name=None,
         )
@@ -1453,6 +1504,7 @@ def _run_single_model(
             dropped_count=0,
             flagged_count=0,
             rendered_text="",
+            footer_text="",
             duration_seconds=time.monotonic() - start,
             exception_class_name=type(exc).__name__,
         )
@@ -1812,6 +1864,12 @@ def cmd_generate(args: argparse.Namespace) -> int:
         )
         if single_outcome.rendered_text:
             sys.stdout.write(single_outcome.rendered_text)
+        # Issue #211 — emit the end-of-run footer to STDERR after the stdout
+        # diff so it reads below the table (and ``> diffs.txt`` captures only
+        # the diff). ``footer_text`` is "" under --quiet / non-TTY / failure.
+        if single_outcome.footer_text:
+            sys.stdout.flush()
+            print_stderr(single_outcome.footer_text, allow_sgr=True, flush=True)
         return single_outcome.exit_code
 
     except Exception as exc:  # noqa: BLE001 — the boundary catch (DEC-016)

--- a/tests/cli/test_batch_emission.py
+++ b/tests/cli/test_batch_emission.py
@@ -72,6 +72,7 @@ def _make_outcome(
         dropped_count=dropped,
         flagged_count=flagged,
         rendered_text="rendered\n" if exit_code == 0 else "",
+        footer_text="",
         duration_seconds=duration,
         exception_class_name=exc_class,
     )

--- a/tests/cli/test_generate.py
+++ b/tests/cli/test_generate.py
@@ -1238,6 +1238,33 @@ def test_generate_footer_suppressed_under_quiet(
     assert "done in" not in captured.err
 
 
+def test_generate_footer_dry_run_says_no_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Under ``--dry-run`` the footer reports no deliverables — the
+    ``dry run — no files written`` line, never a ``wrote .signalforge/…``
+    claim (the footer honours the dry-run contract)."""
+    project_dir = make_fake_dbt_project(tmp_path)
+    monkeypatch.chdir(project_dir)
+    _install_happy_patches(monkeypatch)
+    _force_tty(monkeypatch)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+
+    code = main(["generate", "model.shop.customers", "--dry-run"])
+    captured = capsys.readouterr()
+    assert code == 0, f"stderr={captured.err}"
+    plain = strip_ansi_escapes(captured.err)
+    assert "dry run — no files written" in plain
+    assert ".signalforge/diff.json" not in plain
+    assert ".signalforge/grade.json" not in plain
+    assert "wrote " not in plain
+    # The ✓ done line still closes the run.
+    assert any(ln.startswith("✓ done in") for ln in plain.splitlines())
+
+
 def test_generate_no_progress_in_non_tty(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/test_generate.py
+++ b/tests/cli/test_generate.py
@@ -1190,6 +1190,54 @@ def test_generate_progress_plain_path_is_glyph_free_and_byte_stable(
     assert progress_lines, f"expected pre-#210 plain '[1/5] safety:' line in:\n{captured.err}"
 
 
+def test_generate_footer_appears_in_tty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A successful TTY run emits the issue-#211 end-of-run footer on stderr:
+    a ``wrote …`` line naming the artifacts + a ``✓ done in <X>`` line. (Cost
+    degrades to no clause here — the mocked run writes no audit JSONLs.)"""
+    project_dir = make_fake_dbt_project(tmp_path)
+    monkeypatch.chdir(project_dir)
+    _install_happy_patches(monkeypatch)
+    _force_tty(monkeypatch)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+
+    code = main(["generate", "model.shop.customers"])
+    captured = capsys.readouterr()
+    assert code == 0, f"stderr={captured.err}"
+    plain_lines = strip_ansi_escapes(captured.err).splitlines()
+    assert any(ln.startswith("wrote ") for ln in plain_lines), f"no wrote line in {plain_lines}"
+    assert any(ln.startswith("✓ done in") for ln in plain_lines), f"no ✓ done in {plain_lines}"
+    # The default run (no --write, not --dry-run, graded) names the sidecars.
+    joined = "\n".join(plain_lines)
+    assert ".signalforge/diff.json" in joined
+    assert ".signalforge/grade.json" in joined
+    # The footer is on STDERR, never stdout (so `> diffs.txt` stays clean).
+    assert "✓ done in" not in captured.out
+
+
+def test_generate_footer_suppressed_under_quiet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--quiet`` suppresses the end-of-run footer along with the progress."""
+    project_dir = make_fake_dbt_project(tmp_path)
+    monkeypatch.chdir(project_dir)
+    _install_happy_patches(monkeypatch)
+    _force_tty(monkeypatch)
+
+    code = main(["generate", "model.shop.customers", "--quiet"])
+    captured = capsys.readouterr()
+    assert code == 0, f"stderr={captured.err}"
+    assert "wrote " not in captured.err
+    assert "✓" not in captured.err
+    assert "done in" not in captured.err
+
+
 def test_generate_no_progress_in_non_tty(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/test_progress_style.py
+++ b/tests/cli/test_progress_style.py
@@ -14,9 +14,11 @@ import pytest
 from signalforge._common.ansi_safety import strip_ansi_escapes
 from signalforge.cli._helpers import (
     ProgressStyle,
+    build_run_footer,
     emit_batch_progress_entry,
     emit_progress_done,
     emit_progress_entry,
+    format_cost_clause,
     resolve_progress_style,
 )
 
@@ -163,3 +165,100 @@ def test_color_path_strips_user_content_escapes(capsys: pytest.CaptureFixture[st
     err = capsys.readouterr().err
     assert "\x1b[31mevil" not in err  # smuggled red stripped
     assert "evil.a" in strip_ansi_escapes(err)  # literal text survives
+
+
+# ---------------------------------------------------------------------------
+# End-of-run footer (issue #211): format_cost_clause + build_run_footer.
+# ---------------------------------------------------------------------------
+
+
+def test_cost_clause_single_provider() -> None:
+    assert format_cost_clause({"anthropic": 0.13}) == "$0.13 Anthropic"
+
+
+def test_cost_clause_sub_cent_uses_less_than() -> None:
+    assert format_cost_clause({"openai": 0.004}) == "<$0.01 OpenAI"
+
+
+def test_cost_clause_multi_provider_sorted() -> None:
+    # sorted-key order (anthropic before openai) for determinism.
+    clause = format_cost_clause({"openai": 0.50, "anthropic": 0.13})
+    assert clause == "$0.13 Anthropic · $0.50 OpenAI"
+
+
+def test_cost_clause_omits_zero_providers() -> None:
+    assert format_cost_clause({"anthropic": 0.0, "gemini": 0.0}) == ""
+
+
+def test_cost_clause_empty_when_no_providers() -> None:
+    assert format_cost_clause({}) == ""
+
+
+def test_cost_clause_unknown_provider_falls_back_to_key() -> None:
+    assert format_cost_clause({"acme": 1.0}) == "$1.00 acme"
+
+
+def test_footer_plain_path_byte_stable() -> None:
+    footer = build_run_footer(
+        elapsed_seconds=312.0,
+        written=["schema.yml (8 kept)", ".signalforge/diff.json"],
+        dry_run=False,
+        cost_clause="$0.13 Anthropic",
+        style=_PLAIN,
+    )
+    assert footer == (
+        "wrote schema.yml (8 kept) · .signalforge/diff.json\ndone in 5m 12s · $0.13 Anthropic"
+    )
+    assert "\x1b" not in footer
+    assert "✓" not in footer  # glyph is colour-only
+
+
+def test_footer_color_path_has_green_check_and_dim() -> None:
+    footer = build_run_footer(
+        elapsed_seconds=312.0,
+        written=[".signalforge/diff.json"],
+        dry_run=False,
+        cost_clause="$0.13 Anthropic",
+        style=_COLOR24,
+    )
+    # signal-green ✓ glyph (brand #2FCB7F).
+    assert "\x1b[38;2;47;203;127m✓\x1b[0m" in footer
+    assert "\x1b[2m" in footer  # dim artifacts + cost
+    plain = strip_ansi_escapes(footer)
+    assert plain.startswith("wrote .signalforge/diff.json")
+    assert "✓ done in 5m 12s · $0.13 Anthropic" in plain
+
+
+def test_footer_check_uses_16color_fallback() -> None:
+    footer = build_run_footer(
+        elapsed_seconds=1.0, written=[], dry_run=False, cost_clause="", style=_COLOR16
+    )
+    assert "\x1b[32m✓\x1b[0m" in footer  # 16-colour green
+
+
+def test_footer_dry_run_no_files() -> None:
+    plain = strip_ansi_escapes(
+        build_run_footer(
+            elapsed_seconds=5.2, written=[], dry_run=True, cost_clause="", style=_PLAIN
+        )
+    )
+    assert plain == "dry run — no files written\ndone in 5.2s"
+
+
+def test_footer_omits_cost_clause_when_empty() -> None:
+    footer = build_run_footer(
+        elapsed_seconds=1.0,
+        written=[".signalforge/diff.json"],
+        dry_run=False,
+        cost_clause="",
+        style=_PLAIN,
+    )
+    assert footer == "wrote .signalforge/diff.json\ndone in 1.0s"
+
+
+def test_footer_no_wrote_line_when_nothing_written_and_not_dry_run() -> None:
+    # Degenerate: not dry-run but caller passed no artifacts — only the done line.
+    footer = build_run_footer(
+        elapsed_seconds=1.0, written=[], dry_run=False, cost_clause="", style=_PLAIN
+    )
+    assert footer == "done in 1.0s"


### PR DESCRIPTION
## What

A successful **single-model** `signalforge generate` run now closes with a two-line stderr footer, printed below the diff:

```
wrote schema.yml (8 kept) · .signalforge/diff.json · .signalforge/grade.json
✓ done in 5m12s · $0.13 Anthropic
```

Third child of the brand-CLI epic (#208), reusing the #210 progress style + the `_common.palette`.

## How

- **`build_run_footer` / `format_cost_clause` / `_format_usd` / `_check_glyph`** in `_helpers.py`. The `✓` is signal-green (`palette.SIGNAL`/`GREEN`); glyph + dim styling appear only when colour is on (reuses the #210 `ProgressStyle`); the colour-off form is plain text.
- **Built in `_run_single_model`, emitted by the dispatcher after the stdout diff.** Stored on `_SingleModelOutcome.footer_text`; the dispatcher does `sys.stdout.write(diff)` → `flush()` → `print_stderr(footer, allow_sgr=True)` so the footer reads *below* the table and `> diffs.txt` still captures only the diff.
- **Single-model only** — a batch closes with `format_batch_summary` (per-model cost would be cumulative across the append-only audit JSONLs); `footer_text=""` in batch.

## The two lines

- **`wrote …` is honest** — names only artifacts actually written this run: `schema.yml (N kept)` + proposed `.sql` count under `--write`; `.signalforge/diff.json` unless `--dry-run`; `.signalforge/grade.json` when graded. Empty under `--dry-run` → `dry run — no files written`.
- **`✓ done · $cost`** — wall-clock + per-provider LLM cost from `signalforge.llm.cost.rollup_audit_dir`. Cost is **supplementary** (cli-layer.md DEC-005): a rollup failure (missing/malformed audit, unpriced SKU) degrades to a bare `✓ done in <X>`, never fails the run. Sub-cent renders `<$0.01`. **Warehouse cost is omitted** — there's no actual-bytes-scanned figure at end-of-run (`--estimate` is the planner preview).

## Honoring the gates

`--quiet` / non-TTY suppress the footer (gated by `progress_on`); the glyph + colour are colour-terminal-only; the footer is stderr, not stdout.

## Tests

- `test_progress_style.py` — `format_cost_clause` (single/multi-sorted/sub-cent/zero-skip/unknown-provider) + `build_run_footer` (colour/plain/dry-run/no-cost/green-✓/16-colour fallback).
- `test_generate.py` — footer appears in a TTY run (on stderr, not stdout) + `--quiet` suppression.

## Validation

`uv run ruff check . && uv run ruff format --check . && uv run pyright && uv run pytest` — all green (3771 passed, 8 skipped, pyright 0 errors). End-to-end verified via `build_run_footer` (colour / plain / dry-run).

Closes #211. Part of #208.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `generate` command now prints a two-line end-of-run stderr footer (what was written / “✓ done in <X> · $…”), shown after the diff; suppressed for batch runs, non-TTY, or `--quiet`. `--dry-run` reports no deliverables. `--select` yields batch summary instead of per-model footer.

* **Behavior**
  * Aggregated LLM cost is displayed (sub-$0.01 shown as "<$0.01"); cost rollups fail-soft to an empty cost clause. Color and check glyph are TTY-gated.

* **Tests**
  * Added tests covering footer emission, suppression, wording, and cost formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->