### PR TITLE
docs: feature Airflow integration in README + refresh deep-dive status

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ And you don't have to start from SignalForge's own drafts. Point it at a `schema
 - **Reports what was kept and what was dropped**, with a one-line "why" per artifact. No black-box generation.
 - **Prunes tests you already have.** Point it at an existing `schema.yml` — from dbt-codegen, dbt Copilot, DinoAI, datapilot, or hand-written — and the warehouse tells you which of *those* tests add no signal. Same prune step, no LLM call (`signalforge prune-existing`).
 - **Drives end-to-end from Claude Code.** Run `signalforge install-skill` once in your dbt project and Claude recognises requests like "draft tests for `dim_customers`" or "prune my existing `schema.yml`," picks the right subcommand + flags, and explains the kept / kept-uncertain / dropped / flagged diff back. Deep dive: [Claude Code skill](docs/skills.md).
+- **Runs on a schedule in Airflow.** Drop the pipeline into a DAG — nightly against changed models, or downstream of a `dbt build` — for run-over-run **schema-drift / signal-rot detection**: get paged the day a test that *used* to catch failing rows silently starts always-passing. Three operators + a `SignalForgeHook` map Airflow Connections to credentials and graded results to task state + XCom, all behind an optional extra (the core install never pulls Airflow in). Deep dive: [Airflow integration](docs/airflow-ops.md).
 
 ## What tests SignalForge generates
 
@@ -573,6 +574,55 @@ silently happen. A reviewer correlates the two streams by
 [docs/draft-ops.md](docs/draft-ops.md) for the response-audit schema,
 the retry taxonomy, the cache pre-send checks, and the typed-error
 reference.
+
+## Orchestration: scheduled drift detection (Airflow)
+
+SignalForge ships a first-class Apache Airflow integration so dbt shops can run the
+pipeline **on a schedule** — nightly against changed models, or downstream of a
+`dbt build` — instead of ad-hoc from the CLI. The headline scheduled value-add is
+**signal-rot detection**: a run-over-run comparison that pages you the day a test which
+*used* to catch failing rows silently starts always-passing. That drift is exactly the
+schema rot this product exists to surface — it turns SignalForge from a generator into a
+monitor.
+
+Three operators + a hook, all behind the `[airflow]` optional extra. The core
+`pip install signalforge-dbt` **never** pulls Airflow in; every `airflow.*` import is
+confined to the `signalforge.airflow` subpackage.
+
+| Surface | Role |
+| --- | --- |
+| `SignalForgeGenerateOperator` | Wraps `generate` (single model or `--select` batch). `write=False` runs `--dry-run` — the safe, read-only scheduled default |
+| `SignalForgePruneExistingOperator` | Wraps the no-LLM, read-only `prune-existing` — a **zero-credential** signal-rot monitor |
+| `SignalForgeDriftOperator` | Compares this run's diff against a prior run's sidecar and gates the DAG on newly-always-passing tests or grade regressions |
+| `SignalForgeHook` | Maps an Airflow Connection/Variable to the dbt `profiles.yml` + LLM API key — credentials never reach task logs or XCom |
+
+Graded results map onto Airflow the way you'd expect: the CLI's four-tier exit-code
+taxonomy drives task state (success / retryable / fail), flagged or drift-alarming runs
+fail or branch to a review task via `on_flagged` / `on_drift` (most-severe-wins), and
+tier counts + sidecar paths surface as XCom for downstream alerting.
+
+```python
+from signalforge.airflow import SignalForgeGenerateOperator
+
+# Nightly: regenerate stg_orders read-only and page if a kept test rotted to always-pass.
+monitor = SignalForgeGenerateOperator(
+    task_id="drift_monitor",
+    project_dir="/opt/dbt/my_project",
+    model="models/staging/stg_orders.sql",
+    write=False,                       # read-only scheduled default (--dry-run)
+    as_of="{{ ds }}",                  # reproducibility anchor for time-bound tests
+    # Compare against yesterday's persisted diff; persist today's for tomorrow.
+    detect_drift_against="/opt/airflow/sf_history/{{ macros.ds_add(ds, -1) }}/diff.json",
+    drift_history_dir="/opt/airflow/sf_history/{{ ds }}",
+    on_drift="fail",                   # alarming drift → hard, no-retry failure
+)
+```
+
+Install steps (the constraints-pinned `[airflow]` environment), the full
+result→task-state table, every operator's params, the `SignalForgeHook` credential flow,
+the date-stamped drift-history pattern, managed-runtime notes (Astronomer / MWAA /
+Composer), and runnable example DAGs live in the deep dive:
+**[Airflow integration](docs/airflow-ops.md)**.
 
 ## Roadmap
 

--- a/docs/airflow-ops.md
+++ b/docs/airflow-ops.md
@@ -5,13 +5,19 @@ DAG — turning the CLI from an ad-hoc tool into a **scheduled schema-drift / si
 monitor**. Consistent with Architectural Commitment #4 (OSS-first, Core-friendly): an
 Airflow DAG runs against any dbt-core project, no dbt Cloud dependency.
 
-> **Status (v0.7).** Two dedicated operators have landed (epic #228): the
-> **`SignalForgeGenerateOperator`** (issue #232 —
+> **Status (v0.7).** Epic #228 landed in full: three operators plus a credential hook,
+> all reusing the one result→task-state + XCom contract documented here.
+> The **`SignalForgeGenerateOperator`** (issue #232 —
 > [section](#signalforgegenerateoperator)) wraps `signalforge generate` (single model or
-> a `--select` batch), and the **`SignalForgePruneExistingOperator`** (issue #233 —
+> a `--select` batch); the **`SignalForgePruneExistingOperator`** (issue #233 —
 > [section](#signalforgepruneexistingoperator)) wraps the no-LLM, read-only
 > `signalforge prune-existing` (ingest → prune → diff) as a zero-credential signal-rot
-> monitor. Both reuse the exact same result→task-state + XCom contract documented here.
+> monitor; the **`SignalForgeDriftOperator`** (issue #235 —
+> [section](#drift--signal-rot-detection)) gates a DAG on run-over-run drift by comparing
+> two persisted `diff.json` sidecars (no CLI call, no credentials); and the
+> **`SignalForgeHook`** (issue #234 —
+> [section](#airflow-native-credentials-signalforgehook--signalforge_conn_id)) maps an
+> Airflow Connection/Variable to the dbt `profiles.yml` + LLM API key.
 > The **example DAG** that drives the pipeline through the `signalforge.airflow` helpers
 > (`run_signalforge` + `decide_task_outcome` + `raise_for_outcome`) from a
 > `PythonOperator` still ships as a from-scratch reference; the operators collapse both


### PR DESCRIPTION
## What

The v0.7 Airflow integration (epic #228) fully landed on `dev` — three operators (`SignalForgeGenerateOperator`, `SignalForgePruneExistingOperator`, `SignalForgeDriftOperator`) + `SignalForgeHook` — but the README surfaced it **only** as a planned roadmap row. This promotes it to a featured, current capability and fixes a stale note in the deep dive.

## Changes

- **`README.md`**
  - New *What it does* bullet — "Runs on a schedule in Airflow" — for top-level discoverability, mirroring the Claude Code bullet, with a deep-dive link.
  - New `## Orchestration: scheduled drift detection (Airflow)` section before the Roadmap: signal-rot framing, a four-row operator/hook table, the result→task-state summary, a runnable `SignalForgeGenerateOperator` drift example (copied verbatim from the deep dive so it parses), and a bold link to `docs/airflow-ops.md`.
- **`docs/airflow-ops.md`**
  - Refreshed the status note, which still claimed *two* operators (written between #233 and #235/#234). Now reflects all three operators + `SignalForgeHook`, each with a verified in-doc anchor.

## Notes

- The v0.7 roadmap row is left as-is — landed features here carry both a roadmap row (release tracking) and a capability section.
- `mkdocs build` is clean; no new link warnings introduced (verified the two new anchors resolve).
- Scope is docs-only; two files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Airflow integration documentation to describe scheduled schema-drift and signal-rot detection
  * Added detailed documentation for three operators and the credential mapping hook connecting to dbt profiles and LLM APIs
  * Provided example DAG configuration demonstrating operator usage and how detection results map to Airflow task states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->